### PR TITLE
added VelocityEstimator with randomized tests

### DIFF
--- a/cob_omni_drive_controller/CMakeLists.txt
+++ b/cob_omni_drive_controller/CMakeLists.txt
@@ -178,11 +178,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
 ## Testing ##
 #############
 
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_cob_omni_drive_controller.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)
+if(CATKIN_ENABLE_TESTING)
+  catkin_add_gtest(${PROJECT_NAME}_velocity_estimator_test  test/velocity_estimator_test.cpp)
+  target_link_libraries(${PROJECT_NAME}_velocity_estimator_test ${catkin_LIBRARIES})
+endif()

--- a/cob_omni_drive_controller/CMakeLists.txt
+++ b/cob_omni_drive_controller/CMakeLists.txt
@@ -5,7 +5,7 @@ project(cob_omni_drive_controller)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
-  controller_interface angles hardware_interface sensor_msgs geometry_msgs nav_msgs tf urdf
+  controller_interface cob_srvs angles hardware_interface sensor_msgs geometry_msgs nav_msgs tf urdf
 )
 
 ## System dependencies are found with CMake's conventions

--- a/cob_omni_drive_controller/include/cob_omni_drive_controller/OdometryTracker.h
+++ b/cob_omni_drive_controller/include/cob_omni_drive_controller/OdometryTracker.h
@@ -75,7 +75,11 @@ public:
         odom_.pose.pose.position.x = 0;
         odom_.pose.pose.position.y = 0;
         odom_.pose.pose.orientation = tf::createQuaternionMsgFromYaw(theta_rob_rad_);
-        
+
+    }
+    void reset(const ros::Time &now){
+        boost::mutex::scoped_lock lock(mutex_);
+        init(now);
     }
     const nav_msgs::Odometry getOdometry(){
         boost::mutex::scoped_lock lock(mutex_);

--- a/cob_omni_drive_controller/include/cob_omni_drive_controller/UndercarriageCtrlGeomROS.h
+++ b/cob_omni_drive_controller/include/cob_omni_drive_controller/UndercarriageCtrlGeomROS.h
@@ -4,11 +4,14 @@
 
 #include <ros/ros.h>
 #include <cob_omni_drive_controller/UndercarriageCtrlGeom.h>
+#include <cob_omni_drive_controller/VelocityEstimator.h>
 
 namespace cob_omni_drive_controller{
     
 bool parseWheelParams(std::vector<UndercarriageGeom::WheelParams> &params, const ros::NodeHandle &nh, bool read_urdf = true);
 bool parseWheelParams(std::vector<UndercarriageCtrl::WheelParams> &params, const ros::NodeHandle &nh, bool read_urdf = true);
+
+VelocityEstimator parseVelocityEstimator(const ros::NodeHandle &nh, const std::string &name);
 
 }
 #endif

--- a/cob_omni_drive_controller/include/cob_omni_drive_controller/VelocityEstimator.h
+++ b/cob_omni_drive_controller/include/cob_omni_drive_controller/VelocityEstimator.h
@@ -1,0 +1,32 @@
+#ifndef COB_OMNI_DRIVE_CONTROLLER_VELOCITY_ESTIMATOR_H_
+#define COB_OMNI_DRIVE_CONTROLLER_VELOCITY_ESTIMATOR_H_
+
+#include <limits>
+#include <cmath>
+
+
+class VelocityEstimator {
+    double overflow_;
+    double overflow_twice_;
+    double last_pos_;
+    double norm(double val){
+        while(val >= overflow_){
+            val -= overflow_twice_;
+        }
+        while(val < -overflow_){
+            val += overflow_twice_;
+        }
+        return val;
+    }
+public:
+    VelocityEstimator(double overflow) : overflow_(overflow), overflow_twice_(overflow*2) {  reset(); }
+    double estimateVelocity(double pos, double vel, double period) {
+        if(overflow_ > 0 && period >  0 && !std::isnan(last_pos_)) vel = norm( pos - last_pos_) / period;
+        else if(overflow_ < 0 && period >  0 && !std::isnan(last_pos_)) vel = ( pos - last_pos_) / period;
+        last_pos_ = pos;
+        return vel;
+    }
+    void reset() { last_pos_ = std::numeric_limits<double>::quiet_NaN(); }
+};
+
+#endif

--- a/cob_omni_drive_controller/include/cob_omni_drive_controller/VelocityEstimator.h
+++ b/cob_omni_drive_controller/include/cob_omni_drive_controller/VelocityEstimator.h
@@ -21,8 +21,11 @@ class VelocityEstimator {
 public:
     VelocityEstimator(double overflow) : overflow_(overflow), overflow_twice_(overflow*2) {  reset(); }
     double estimateVelocity(double pos, double vel, double period) {
-        if(overflow_ > 0 && period >  0 && !std::isnan(last_pos_)) vel = norm( pos - last_pos_) / period;
-        else if(overflow_ < 0 && period >  0 && !std::isnan(last_pos_)) vel = ( pos - last_pos_) / period;
+        if(period > 0 && !std::isnan(last_pos_)){
+            if(overflow_ > 0) vel = norm(pos - last_pos_) / period; // derive without overflow correction
+            else if(overflow_ < 0) vel = (pos - last_pos_) / period; // derive only
+            // else turn off estimation
+        }
         last_pos_ = pos;
         return vel;
     }

--- a/cob_omni_drive_controller/package.xml
+++ b/cob_omni_drive_controller/package.xml
@@ -40,6 +40,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>angles</build_depend>
+  <build_depend>cob_srvs</build_depend>
   <build_depend>controller_interface</build_depend>
   <build_depend>hardware_interface</build_depend>
   <build_depend>sensor_msgs</build_depend>
@@ -49,8 +50,9 @@
   <build_depend>urdf</build_depend>
 
   <run_depend>angles</run_depend>
+  <run_depend>cob_srvs</run_depend>
   <run_depend>controller_interface</run_depend>
-  <run_depend>controller_interface</run_depend>
+  <run_depend>hardware_interface</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>nav_msgs</run_depend>

--- a/cob_omni_drive_controller/src/control_plugin.cpp
+++ b/cob_omni_drive_controller/src/control_plugin.cpp
@@ -49,12 +49,14 @@ public:
         return true;
   }
     virtual void starting(const ros::Time& time){
+        GeomController::reset();
         geom_->reset();
         target_.updated = false;
     }
-    virtual void update(const ros::Time& time, const ros::Duration& period){
+    virtual void update(const ros::Time& time, const ros::Duration& duration){
+        double period = duration.toSec();
 
-        GeomController::update();
+        GeomController::update(period);
 
         {
             boost::mutex::scoped_try_lock lock(mutex_);
@@ -75,7 +77,7 @@ public:
             }
         }
 
-        geom_->calcControlStep(wheel_commands_, period.toSec(), false);
+        geom_->calcControlStep(wheel_commands_, period, false);
 
         for (unsigned i=0; i<wheel_commands_.size(); i++){
             steer_joints_[i].setCommand(wheel_commands_[i].dVelGearSteerRadS);

--- a/cob_omni_drive_controller/src/odom_plugin.cpp
+++ b/cob_omni_drive_controller/src/odom_plugin.cpp
@@ -8,6 +8,8 @@
 #include <cob_omni_drive_controller/UndercarriageCtrlGeom.h>
 #include <cob_omni_drive_controller/OdometryTracker.h>
 
+#include <cob_srvs/Trigger.h>
+
 #include "GeomController.h"
 
 namespace cob_omni_drive_controller
@@ -47,6 +49,7 @@ public:
         }
 
         publish_timer_ = controller_nh.createTimer(ros::Duration(1/publish_rate), &OdometryController::publish, this);
+	service_reset_ = controller_nh.advertiseService("reset_odometry", &OdometryController::srv_reset, this);
 
         return true;
   }
@@ -54,6 +57,17 @@ public:
         GeomController::reset();
         odom_tracker_->init(time);
     }
+
+    virtual bool srv_reset(cob_srvs::Trigger::Request &req, cob_srvs::Trigger::Response &res)
+    {
+        ROS_INFO("Resetting odometry to zero.");
+        
+        GeomController::reset();
+        res.success.data = init_;
+
+        return true;
+    }
+
     virtual void update(const ros::Time& time, const ros::Duration& duration){
         double period = duration.toSec();
 
@@ -69,6 +83,7 @@ private:
     UndercarriageGeom::PlatformState platform_state_;
 
     ros::Publisher topic_pub_odometry_;                 // calculated (measured) velocity, rotation and pose (odometry-based) for the robot
+    ros::ServiceServer service_reset_;			// service to reset odometry to zero
 
     boost::scoped_ptr<tf::TransformBroadcaster> tf_broadcast_odometry_;    // according transformation for the tf broadcaster
     boost::scoped_ptr<OdometryTracker> odom_tracker_;

--- a/cob_omni_drive_controller/src/odom_plugin.cpp
+++ b/cob_omni_drive_controller/src/odom_plugin.cpp
@@ -60,10 +60,14 @@ public:
 
     virtual bool srv_reset(cob_srvs::Trigger::Request &req, cob_srvs::Trigger::Response &res)
     {
-        ROS_INFO("Resetting odometry to zero.");
-        
-        GeomController::reset();
-        res.success.data = init_;
+        if(!isRunning()){
+            res.error_message.data = "not running";
+            res.success.data = false;
+        }else{
+            odom_tracker_->reset(ros::Time::now());
+            res.success.data = true;
+            ROS_INFO("Resetting odometry to zero.");
+        }
 
         return true;
     }

--- a/cob_omni_drive_controller/src/odom_plugin.cpp
+++ b/cob_omni_drive_controller/src/odom_plugin.cpp
@@ -52,10 +52,10 @@ public:
 	service_reset_ = controller_nh.advertiseService("reset_odometry", &OdometryController::srv_reset, this);
 
         return true;
-  }
+    }
     virtual void starting(const ros::Time& time){
         GeomController::reset();
-        odom_tracker_->init(time);
+        if(time != stop_time_) odom_tracker_->init(time); // do not init odometry on restart
     }
 
     virtual bool srv_reset(cob_srvs::Trigger::Request &req, cob_srvs::Trigger::Response &res)
@@ -81,7 +81,7 @@ public:
 
         odom_tracker_->track(time, period, platform_state_.getVelX(), platform_state_.getVelY(), platform_state_.dRotRobRadS);
     }
-    virtual void stopping(const ros::Time& time) {}
+    virtual void stopping(const ros::Time& time) { stop_time_ = time; }
 
 private:
     UndercarriageGeom::PlatformState platform_state_;
@@ -93,6 +93,7 @@ private:
     boost::scoped_ptr<OdometryTracker> odom_tracker_;
     ros::Timer publish_timer_;
     geometry_msgs::TransformStamped odom_tf_;
+    ros::Time stop_time_;
   
   
     void publish(const ros::TimerEvent&){

--- a/cob_omni_drive_controller/src/odom_plugin.cpp
+++ b/cob_omni_drive_controller/src/odom_plugin.cpp
@@ -51,15 +51,17 @@ public:
         return true;
   }
     virtual void starting(const ros::Time& time){
+        GeomController::reset();
         odom_tracker_->init(time);
     }
-    virtual void update(const ros::Time& time, const ros::Duration& period){
+    virtual void update(const ros::Time& time, const ros::Duration& duration){
+        double period = duration.toSec();
 
-        GeomController::update();
+        GeomController::update(period);
 
         geom_->calcDirect(platform_state_);
 
-        odom_tracker_->track(time, period.toSec(), platform_state_.getVelX(), platform_state_.getVelY(), platform_state_.dRotRobRadS);
+        odom_tracker_->track(time, period, platform_state_.getVelX(), platform_state_.getVelY(), platform_state_.dRotRobRadS);
     }
     virtual void stopping(const ros::Time& time) {}
 

--- a/cob_omni_drive_controller/src/param_parser.cpp
+++ b/cob_omni_drive_controller/src/param_parser.cpp
@@ -209,5 +209,13 @@ bool parseWheelParams(std::vector<UndercarriageCtrl::WheelParams> &params, const
     return parseWheels(params, nh, read_urdf);
 }
 
+VelocityEstimator parseVelocityEstimator(const ros::NodeHandle &nh, const std::string &name){
+    double overflow_period = 0.0;
+    nh.getParam("defaults/estimate_velocity_with_overflow", overflow_period);
+    nh.getParam("estimate_velocity_with_overflow/"+name, overflow_period);
+    if(overflow_period < 0) overflow_period = -1.0;
+    return VelocityEstimator(overflow_period);
+}
     
 }
+

--- a/cob_omni_drive_controller/test/velocity_estimator_test.cpp
+++ b/cob_omni_drive_controller/test/velocity_estimator_test.cpp
@@ -1,0 +1,151 @@
+#include <cob_omni_drive_controller/VelocityEstimator.h>
+#include <gtest/gtest.h>
+#include "boost/random.hpp"
+
+class Randomizer : public boost::variate_generator<boost::mt19937, boost::uniform_real<double> >{
+public:
+    Randomizer() : boost::variate_generator<boost::mt19937, boost::uniform_real<double> >(boost::mt19937(std::time(0)), boost::uniform_real<double>(std::numeric_limits<double>::min(),std::numeric_limits<double>::max())) {}
+    Randomizer(double limit) : boost::variate_generator<boost::mt19937, boost::uniform_real<double> >(boost::mt19937(std::time(0)), boost::uniform_real<double>(-limit, limit)) {}
+    Randomizer(double min, double max) : boost::variate_generator<boost::mt19937, boost::uniform_real<double> >(boost::mt19937(std::time(0)), boost::uniform_real<double>(min,max)) {}
+};
+
+TEST(VelocityEstimatorTest, ZeroOverflowTest)
+{
+    VelocityEstimator est(0.0);
+
+    Randomizer rnd;
+
+    for(int i=0; i < 100; ++i){
+        double vel = rnd();
+        EXPECT_DOUBLE_EQ(vel, est.estimateVelocity(rnd(), vel, 1.0));
+    }
+
+}
+
+TEST(VelocityEstimatorTest, InfiniteOverflowTest)
+{
+    double half_max = std::numeric_limits<double>::max()/2.0;
+    Randomizer rnd;
+
+    {
+        VelocityEstimator est(-1);
+        ASSERT_DOUBLE_EQ(0.0, est.estimateVelocity(0,0,1.0));
+        ASSERT_DOUBLE_EQ(-half_max,est.estimateVelocity(-half_max ,rnd(),1.0));
+        ASSERT_EQ(std::numeric_limits<double>::max(), est.estimateVelocity(half_max,rnd(),1.0));
+    }
+    {
+        VelocityEstimator est(half_max);
+        ASSERT_DOUBLE_EQ(0.0, est.estimateVelocity(0,0,1.0));
+        ASSERT_DOUBLE_EQ(-half_max,est.estimateVelocity(-half_max ,rnd(),1.0));
+        ASSERT_EQ(0, est.estimateVelocity(half_max,rnd(),1.0));  // zeor means overflow
+    }
+}
+
+TEST(VelocityEstimatorTest, TestOverflowPos)
+{
+    Randomizer rnd;
+    Randomizer time_rnd(0,10.0);
+
+    for(int n=1; n < 100; ++n)
+    {
+        double overflow = Randomizer(0, 1000)();
+        Randomizer half(1e-6,overflow/2.0);
+
+        VelocityEstimator est(overflow);
+
+        double start = Randomizer(overflow)();
+        ASSERT_DOUBLE_EQ(0.0, est.estimateVelocity(start,0,1.0));
+
+        double p = start, step, dt;
+        while(1){
+            step = half();
+            dt = time_rnd();
+            if(step == 0.0) continue;
+            if(p + step > overflow) break;
+            p += step;
+            EXPECT_NEAR(step/dt, est.estimateVelocity(p, rnd(), dt), 1e-6);
+        }
+        p -= 2*overflow;
+        while(1){
+            step = half();
+            dt = time_rnd();
+            if(step == 0.0) continue;
+            p += step;
+            if(p + step > start) break;
+            EXPECT_NEAR(step/dt, est.estimateVelocity(p, rnd(), dt), 1e-6);
+        }
+
+    }
+}
+
+TEST(VelocityEstimatorTest, TestOverflowNeg)
+{
+    Randomizer rnd;
+    Randomizer time_rnd(0,10.0);
+
+    for(int n=1; n < 100; ++n)
+    {
+        double overflow = Randomizer(0, 1000)();
+        Randomizer half(-overflow/2.0,0.0);
+
+        VelocityEstimator est(overflow);
+
+        double start = Randomizer(overflow)();
+        ASSERT_DOUBLE_EQ(0.0, est.estimateVelocity(start,0,1.0));
+
+        double p = start, step, dt;
+        while(1){
+            step = half();
+            dt = time_rnd();
+            if(step == 0.0) continue;
+            if(p + step < -overflow) break;
+            p += step;
+            EXPECT_NEAR(step/dt, est.estimateVelocity(p, rnd(), dt), 1e-6);
+        }
+        p += 2*overflow;
+        while(1){
+            step = half();
+            dt = time_rnd();
+            if(step == 0.0) continue;
+            p += step;
+            if(p + step < start) break;
+            EXPECT_NEAR(step/dt, est.estimateVelocity(p, rnd(), dt), 1e-6);
+        }
+
+    }
+
+}
+
+
+TEST(VelocityEstimatorTest, TestNoMove)
+{
+    VelocityEstimator est(10.0);
+    Randomizer rnd;
+
+    ASSERT_DOUBLE_EQ(0.0, est.estimateVelocity(0,0,0));
+
+    for(int j=0; j < 100; ++j){
+        EXPECT_DOUBLE_EQ(0.0, est.estimateVelocity(0, rnd(), 1.0));
+    }
+
+}
+
+TEST(VelocityEstimatorTest, TestReset)
+{
+    VelocityEstimator est(10.0);
+    Randomizer pos_rnd(10.0);
+    Randomizer rnd;
+
+    for(int i=0; i < 100; ++i){
+        double vel = rnd();
+        EXPECT_DOUBLE_EQ(vel, est.estimateVelocity(pos_rnd(), vel, 1.0));
+        est.reset();
+    }
+
+}
+
+// Run all the tests that were declared with TEST()
+int main(int argc, char **argv){
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/cob_twist_controller/src/augmented_solver.cpp
+++ b/cob_twist_controller/src/augmented_solver.cpp
@@ -1,6 +1,7 @@
 #include "ros/ros.h"
 
 #include "cob_twist_controller/augmented_solver.h"
+#include <Eigen/Geometry>
 
 
 augmented_solver::augmented_solver(const KDL::Chain& chain, double eps, int maxiter):


### PR DESCRIPTION
Estimate velocity if measured velocity is too noisy or faulty.
Added parameter "defaults/estimate_velocity_with_overflow" and per-joint "estimate_velocity_with_overflow/JOINT_NAME".

Zero (default) means no estimation.
Value < Zero: Estimation without overflow.
Vaue > Zero: The postion values must be in the range [-value, value) and value must be greater than twice the maximum velocity.
