### PR TITLE
Improved cob_omni_drive_controller

### DIFF
--- a/cob_omni_drive_controller/CMakeLists.txt
+++ b/cob_omni_drive_controller/CMakeLists.txt
@@ -5,7 +5,7 @@ project(cob_omni_drive_controller)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
-  controller_interface cob_srvs angles hardware_interface sensor_msgs geometry_msgs nav_msgs tf urdf
+  controller_interface std_srvs angles hardware_interface sensor_msgs geometry_msgs nav_msgs tf urdf
 )
 
 ## System dependencies are found with CMake's conventions
@@ -80,7 +80,7 @@ find_package(Boost REQUIRED) # COMPONENTS system)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES cob_omni_drive_geom cob_omni_drive_controller
-  CATKIN_DEPENDS sensor_msgs tf geometry_msgs nav_msgs
+  CATKIN_DEPENDS sensor_msgs tf geometry_msgs nav_msgs std_srvs
 #  DEPENDS system_lib
 )
 

--- a/cob_omni_drive_controller/CMakeLists.txt
+++ b/cob_omni_drive_controller/CMakeLists.txt
@@ -5,7 +5,7 @@ project(cob_omni_drive_controller)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
-  controller_interface angles hardware_interface sensor_msgs geometry_msgs nav_msgs tf urdf
+  controller_interface cob_srvs angles hardware_interface sensor_msgs geometry_msgs nav_msgs tf urdf
 )
 
 ## System dependencies are found with CMake's conventions

--- a/cob_omni_drive_controller/include/cob_omni_drive_controller/OdometryTracker.h
+++ b/cob_omni_drive_controller/include/cob_omni_drive_controller/OdometryTracker.h
@@ -48,7 +48,6 @@
 class OdometryTracker{
     nav_msgs::Odometry odom_;
     double theta_rob_rad_;
-    boost::mutex mutex_;
 public:
     OdometryTracker(const std::string &from = "/wheelodom", const std::string &to = "/base_footprint" , double cov_pose = 0.1, double cov_twist = 0.1) {
         odom_.header.frame_id = from;
@@ -77,20 +76,13 @@ public:
         odom_.pose.pose.orientation = tf::createQuaternionMsgFromYaw(theta_rob_rad_);
 
     }
-    void reset(const ros::Time &now){
-        boost::mutex::scoped_lock lock(mutex_);
-        init(now);
-    }
-    const nav_msgs::Odometry getOdometry(){
-        boost::mutex::scoped_lock lock(mutex_);
+    const nav_msgs::Odometry &getOdometry(){
         return odom_;
     }
     void track(const ros::Time &now, double dt, double vel_x, double vel_y, double vel_theta){
-        boost::mutex::scoped_try_lock lock(mutex_);
-        
         // calculation from ROS odom publisher tutorial http://www.ros.org/wiki/navigation/Tutorials/RobotSetup/Odom, using now midpoint integration
 
-        if(lock && dt > 0){
+        if(dt > 0){
             odom_.header.stamp = now;
 
             double vel_x_mid = (vel_x+odom_.twist.twist.linear.x)/2.0;

--- a/cob_omni_drive_controller/include/cob_omni_drive_controller/OdometryTracker.h
+++ b/cob_omni_drive_controller/include/cob_omni_drive_controller/OdometryTracker.h
@@ -75,7 +75,11 @@ public:
         odom_.pose.pose.position.x = 0;
         odom_.pose.pose.position.y = 0;
         odom_.pose.pose.orientation = tf::createQuaternionMsgFromYaw(theta_rob_rad_);
-        
+
+    }
+    void reset(const ros::Time &now){
+        boost::mutex::scoped_lock lock(mutex_);
+        init(now);
     }
     const nav_msgs::Odometry getOdometry(){
         boost::mutex::scoped_lock lock(mutex_);

--- a/cob_omni_drive_controller/package.xml
+++ b/cob_omni_drive_controller/package.xml
@@ -40,6 +40,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>angles</build_depend>
+  <build_depend>cob_srvs</build_depend>
   <build_depend>controller_interface</build_depend>
   <build_depend>hardware_interface</build_depend>
   <build_depend>sensor_msgs</build_depend>
@@ -49,8 +50,9 @@
   <build_depend>urdf</build_depend>
 
   <run_depend>angles</run_depend>
+  <run_depend>cob_srvs</run_depend>
   <run_depend>controller_interface</run_depend>
-  <run_depend>controller_interface</run_depend>
+  <run_depend>hardware_interface</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>nav_msgs</run_depend>

--- a/cob_omni_drive_controller/package.xml
+++ b/cob_omni_drive_controller/package.xml
@@ -40,7 +40,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>angles</build_depend>
-  <build_depend>cob_srvs</build_depend>
+  <build_depend>std_srvs</build_depend>
   <build_depend>controller_interface</build_depend>
   <build_depend>hardware_interface</build_depend>
   <build_depend>sensor_msgs</build_depend>
@@ -50,7 +50,7 @@
   <build_depend>urdf</build_depend>
 
   <run_depend>angles</run_depend>
-  <run_depend>cob_srvs</run_depend>
+  <run_depend>std_srvs</run_depend>
   <run_depend>controller_interface</run_depend>
   <run_depend>hardware_interface</run_depend>
   <run_depend>sensor_msgs</run_depend>

--- a/cob_omni_drive_controller/src/odom_plugin.cpp
+++ b/cob_omni_drive_controller/src/odom_plugin.cpp
@@ -59,10 +59,14 @@ public:
 
     virtual bool srv_reset(cob_srvs::Trigger::Request &req, cob_srvs::Trigger::Response &res)
     {
-        ROS_INFO("Resetting odometry to zero.");
-        
-        GeomController::reset();
-        res.success.data = init_;
+        if(!isRunning()){
+            res.error_message.data = "not running";
+            res.success.data = false;
+        }else{
+            odom_tracker_->reset(ros::Time::now());
+            res.success.data = true;
+            ROS_INFO("Resetting odometry to zero.");
+        }
 
         return true;
     }

--- a/cob_omni_drive_controller/src/odom_plugin.cpp
+++ b/cob_omni_drive_controller/src/odom_plugin.cpp
@@ -52,9 +52,9 @@ public:
 	service_reset_ = controller_nh.advertiseService("reset_odometry", &OdometryController::srv_reset, this);
 
         return true;
-  }
+    }
     virtual void starting(const ros::Time& time){
-        odom_tracker_->init(time);
+        if(time != stop_time_) odom_tracker_->init(time); // do not init odometry on restart
     }
 
     virtual bool srv_reset(cob_srvs::Trigger::Request &req, cob_srvs::Trigger::Response &res)
@@ -79,7 +79,7 @@ public:
 
         odom_tracker_->track(time, period.toSec(), platform_state_.getVelX(), platform_state_.getVelY(), platform_state_.dRotRobRadS);
     }
-    virtual void stopping(const ros::Time& time) {}
+    virtual void stopping(const ros::Time& time) { stop_time_ = time; }
 
 private:
     UndercarriageGeom::PlatformState platform_state_;
@@ -91,6 +91,7 @@ private:
     boost::scoped_ptr<OdometryTracker> odom_tracker_;
     ros::Timer publish_timer_;
     geometry_msgs::TransformStamped odom_tf_;
+    ros::Time stop_time_;
   
   
     void publish(const ros::TimerEvent&){

--- a/cob_omni_drive_controller/src/odom_plugin.cpp
+++ b/cob_omni_drive_controller/src/odom_plugin.cpp
@@ -8,7 +8,7 @@
 #include <cob_omni_drive_controller/UndercarriageCtrlGeom.h>
 #include <cob_omni_drive_controller/OdometryTracker.h>
 
-#include <cob_srvs/Trigger.h>
+#include <std_srvs/Trigger.h>
 
 #include "GeomController.h"
 
@@ -59,16 +59,16 @@ public:
         reset_ = false;
     }
 
-    virtual bool srv_reset(cob_srvs::Trigger::Request &req, cob_srvs::Trigger::Response &res)
+    virtual bool srv_reset(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res)
     {
         if(!isRunning()){
-            res.error_message.data = "not running";
-            res.success.data = false;
+            res.message = "not running";
+            res.success = false;
         }else{
             boost::mutex::scoped_lock lock(mutex_);
             reset_ = true;
             lock.unlock();
-            res.success.data = true;
+            res.success = true;
             ROS_INFO("Resetting odometry to zero.");
         }
 


### PR DESCRIPTION
- added reset_odometry service (std_srvs/Trigger)
- do not reset odometry on immediate controller restarts (e.g. after emergency stops), but on manual restarts
- updates from RT part cannot get lost anymore, but outdated data might be published (RT-safe behaviour)

Tested on cob4-4 and cob4-6.
