### PR TITLE
Fixed message generation issue

### DIFF
--- a/cob_obstacle_distance/CMakeLists.txt
+++ b/cob_obstacle_distance/CMakeLists.txt
@@ -48,6 +48,7 @@ add_dependencies(cob_obstacle_distance ${PROJECT_NAME}_gencpp)
 target_link_libraries(cob_obstacle_distance parsers marker_shapes_management ${fcl_LIBRARIES} ${catkin_LIBRARIES} ${orocos_kdl_LIBRARIES})
 
 add_executable(debug_obstacle_distance_node src/debug/debug_obstacle_distance_node.cpp)
+add_dependencies(debug_obstacle_distance_node ${PROJECT_NAME}_generate_messages)
 target_link_libraries(debug_obstacle_distance_node ${catkin_LIBRARIES})
 
 ### Install ###


### PR DESCRIPTION
This PR fixes compilation issues on clean machine 

/root/workspace/src/cob_control/cob_obstacle_distance/src/debug/debug_obstacle_distance_node.cpp:32:53: fatal error: cob_obstacle_distance/ObstacleDistances.h: No such file or directory
# include "cob_obstacle_distance/ObstacleDistances.h"

^
compilation terminated.

The fix is simple. 
Message generation was added to dependencies of the executable.
