### PR TITLE
use undamped jacobian in nullspace projection

### DIFF
--- a/cob_twist_controller/include/cob_twist_controller/constraint_solvers/solvers/constraint_solver_base.h
+++ b/cob_twist_controller/include/cob_twist_controller/constraint_solvers/solvers/constraint_solver_base.h
@@ -47,7 +47,7 @@ class ConstraintSolver
     public:
         /**
          * The interface method to solve the inverse kinematics problem. Has to be implemented in inherited classes.
-         * @param inCartVelocities The input velocities vector (in cartesian space).
+         * @param in_cart_velocities The input velocities vector (in cartesian space).
          * @param joint_states The joint states with history.
          * @return The calculated new joint velocities.
          */

--- a/cob_twist_controller/src/constraint_solvers/solvers/gradient_projection_method_solver.cpp
+++ b/cob_twist_controller/src/constraint_solvers/solvers/gradient_projection_method_solver.cpp
@@ -45,10 +45,10 @@ Eigen::MatrixXd GradientProjectionMethodSolver::solve(const Vector6d_t& in_cart_
 
     Eigen::MatrixXd particular_solution = damped_pinv * in_cart_velocities;
 
-    Eigen::MatrixXd ident = Eigen::MatrixXd::Identity(damped_pinv.rows(), this->jacobian_data_.cols());
-    Eigen::MatrixXd projector = ident - damped_pinv * this->jacobian_data_;
-    // Eigen::MatrixXd ident = Eigen::MatrixXd::Identity(pinv.rows(), this->jacobian_data_.cols());
-    // Eigen::MatrixXd projector = ident - pinv * this->jacobian_data_;
+    // Eigen::MatrixXd ident = Eigen::MatrixXd::Identity(damped_pinv.rows(), this->jacobian_data_.cols());
+    // Eigen::MatrixXd projector = ident - damped_pinv * this->jacobian_data_;
+    Eigen::MatrixXd ident = Eigen::MatrixXd::Identity(pinv.rows(), this->jacobian_data_.cols());
+    Eigen::MatrixXd projector = ident - pinv * this->jacobian_data_;
 
     Eigen::MatrixXd homogeneous_solution = Eigen::MatrixXd::Zero(particular_solution.rows(), particular_solution.cols());
     KDL::JntArrayVel predict_jnts_vel(joint_states.current_q_.rows());
@@ -66,6 +66,7 @@ Eigen::MatrixXd GradientProjectionMethodSolver::solve(const Vector6d_t& in_cart_
 
     Eigen::MatrixXd qdots_out = particular_solution + this->params_.k_H * homogeneous_solution;  // weighting with k_H is done in loop
 
+    // //DEBUG: for verification of nullspace projection
     // std::stringstream ss_part;
     // ss_part << "particular_solution: ";
     // for(unsigned int i=0; i<particular_solution.rows(); i++)

--- a/cob_twist_controller/src/constraint_solvers/solvers/gradient_projection_method_solver.cpp
+++ b/cob_twist_controller/src/constraint_solvers/solvers/gradient_projection_method_solver.cpp
@@ -37,18 +37,18 @@
  * In addtion to the partial solution q_dot = J^+ * v the homogeneous solution (I - J^+ * J) q_dot_0 is calculated.
  * The q_dot_0 results from the sum of the constraint cost function gradients. The terms of the sum are weighted with a factor k_H separately.
  */
-Eigen::MatrixXd GradientProjectionMethodSolver::solve(const Vector6d_t& inCartVelocities,
+Eigen::MatrixXd GradientProjectionMethodSolver::solve(const Vector6d_t& in_cart_velocities,
                                                       const JointStates& joint_states)
 {
-    Eigen::MatrixXd damped_jpi = pinv_calc_.calculate(this->params_, this->damping_, this->jacobian_data_);
-    Eigen::MatrixXd jpi = pinv_calc_.calculate(this->jacobian_data_);
+    Eigen::MatrixXd damped_pinv = pinv_calc_.calculate(this->params_, this->damping_, this->jacobian_data_);
+    Eigen::MatrixXd pinv = pinv_calc_.calculate(this->jacobian_data_);
 
-    Eigen::MatrixXd particular_solution = damped_jpi * inCartVelocities;
+    Eigen::MatrixXd particular_solution = damped_pinv * in_cart_velocities;
 
-    Eigen::MatrixXd ident = Eigen::MatrixXd::Identity(damped_jpi.rows(), this->jacobian_data_.cols());
-    Eigen::MatrixXd projector = ident - damped_jpi * this->jacobian_data_;
-    // Eigen::MatrixXd ident = Eigen::MatrixXd::Identity(jpi.rows(), this->jacobian_data_.cols());
-    // Eigen::MatrixXd projector = ident - jpi * this->jacobian_data_;
+    Eigen::MatrixXd ident = Eigen::MatrixXd::Identity(damped_pinv.rows(), this->jacobian_data_.cols());
+    Eigen::MatrixXd projector = ident - damped_pinv * this->jacobian_data_;
+    // Eigen::MatrixXd ident = Eigen::MatrixXd::Identity(pinv.rows(), this->jacobian_data_.cols());
+    // Eigen::MatrixXd projector = ident - pinv * this->jacobian_data_;
 
     Eigen::MatrixXd homogeneous_solution = Eigen::MatrixXd::Zero(particular_solution.rows(), particular_solution.cols());
     KDL::JntArrayVel predict_jnts_vel(joint_states.current_q_.rows());
@@ -58,10 +58,10 @@ Eigen::MatrixXd GradientProjectionMethodSolver::solve(const Vector6d_t& inCartVe
         ROS_DEBUG_STREAM("task id: " << (*it)->getTaskId());
         (*it)->update(joint_states, predict_jnts_vel, this->jacobian_data_);
         Eigen::VectorXd q_dot_0 = (*it)->getPartialValues();
-        Eigen::MatrixXd tmpHomogeneousSolution = projector * q_dot_0;
+        Eigen::MatrixXd tmp_projection = projector * q_dot_0;
         double activation_gain = (*it)->getActivationGain();  // contribution of the homo. solution to the part. solution
-        double constraint_k_H = (*it)->getSelfMotionMagnitude(particular_solution, tmpHomogeneousSolution);  // gain of homogenous solution (if active)
-        homogeneous_solution += (constraint_k_H * activation_gain * tmpHomogeneousSolution);
+        double constraint_k_H = (*it)->getSelfMotionMagnitude(particular_solution, tmp_projection);  // gain of homogenous solution (if active)
+        homogeneous_solution += (constraint_k_H * activation_gain * tmp_projection);
     }
 
     Eigen::MatrixXd qdots_out = particular_solution + this->params_.k_H * homogeneous_solution;  // weighting with k_H is done in loop

--- a/cob_twist_controller/src/constraint_solvers/solvers/stack_of_tasks_solver.cpp
+++ b/cob_twist_controller/src/constraint_solvers/solvers/stack_of_tasks_solver.cpp
@@ -40,10 +40,10 @@ Eigen::MatrixXd StackOfTasksSolver::solve(const Vector6d_t& in_cart_velocities,
     double cycle = (now - this->last_time_).toSec();
     this->last_time_ = now;
 
-    Eigen::MatrixXd jacobianPseudoInverse = pinv_calc_.calculate(this->params_, this->damping_, this->jacobian_data_);
-    Eigen::MatrixXd ident = Eigen::MatrixXd::Identity(jacobianPseudoInverse.rows(), this->jacobian_data_.cols());
-    Eigen::MatrixXd projector = ident - jacobianPseudoInverse * this->jacobian_data_;
-    Eigen::MatrixXd particular_solution = jacobianPseudoInverse * in_cart_velocities;
+    Eigen::MatrixXd pinv = pinv_calc_.calculate(this->params_, this->damping_, this->jacobian_data_);
+    Eigen::MatrixXd ident = Eigen::MatrixXd::Identity(pinv.rows(), this->jacobian_data_.cols());
+    Eigen::MatrixXd projector = ident - pinv * this->jacobian_data_;
+    Eigen::MatrixXd particular_solution = pinv * in_cart_velocities;
 
     Eigen::MatrixXd projector_i = Eigen::MatrixXd::Identity(this->jacobian_data_.cols(), this->jacobian_data_.cols());
     Eigen::VectorXd q_i = Eigen::VectorXd::Zero(this->jacobian_data_.cols());
@@ -120,8 +120,8 @@ void StackOfTasksSolver::processState(std::set<ConstraintBase_t>::iterator& it,
 {
     Eigen::VectorXd q_dot_0 = (*it)->getPartialValues();
     const double activation_gain = (*it)->getActivationGain();
-    Eigen::MatrixXd tmpHomogeneousSolution = projector * q_dot_0;
-    const double magnitude = (*it)->getSelfMotionMagnitude(particular_solution, tmpHomogeneousSolution);
+    Eigen::MatrixXd tmp_projection = projector * q_dot_0;
+    const double magnitude = (*it)->getSelfMotionMagnitude(particular_solution, tmp_projection);
     ConstraintState cstate = (*it)->getState();
 
     const double constr_prio = (*it)->getPriorityAsNum();

--- a/cob_twist_controller/src/constraint_solvers/solvers/task_priority_solver.cpp
+++ b/cob_twist_controller/src/constraint_solvers/solvers/task_priority_solver.cpp
@@ -48,10 +48,10 @@ Eigen::MatrixXd TaskPrioritySolver::solve(const Vector6d_t& in_cart_velocities,
 
     Eigen::MatrixXd qdots_out = Eigen::MatrixXd::Zero(this->jacobian_data_.cols(), 1);
     Eigen::VectorXd partial_cost_func = Eigen::VectorXd::Zero(this->jacobian_data_.cols());
-    Eigen::MatrixXd jacobianPseudoInverse = pinv_calc_.calculate(this->params_, this->damping_, this->jacobian_data_);
-    Eigen::MatrixXd ident = Eigen::MatrixXd::Identity(jacobianPseudoInverse.rows(), this->jacobian_data_.cols());
-    Eigen::MatrixXd projector = ident - jacobianPseudoInverse * this->jacobian_data_;
-    Eigen::MatrixXd particular_solution = jacobianPseudoInverse * in_cart_velocities;
+    Eigen::MatrixXd pinv = pinv_calc_.calculate(this->params_, this->damping_, this->jacobian_data_);
+    Eigen::MatrixXd ident = Eigen::MatrixXd::Identity(pinv.rows(), this->jacobian_data_.cols());
+    Eigen::MatrixXd projector = ident - pinv * this->jacobian_data_;
+    Eigen::MatrixXd particular_solution = pinv * in_cart_velocities;
 
     KDL::JntArrayVel predict_jnts_vel(joint_states.current_q_.rows());
 

--- a/cob_twist_controller/src/constraint_solvers/solvers/unconstraint_solver.cpp
+++ b/cob_twist_controller/src/constraint_solvers/solvers/unconstraint_solver.cpp
@@ -35,11 +35,11 @@
  * It calculates the pseudo-inverse of the Jacobian via the base implementation of calculatePinvJacobianBySVD.
  * With the pseudo-inverse the joint velocity vector is calculated.
  */
-Eigen::MatrixXd UnconstraintSolver::solve(const Vector6d_t& inCartVelocities,
+Eigen::MatrixXd UnconstraintSolver::solve(const Vector6d_t& in_cart_velocities,
                                           const JointStates& joint_states)
 {
-    Eigen::MatrixXd jacobianPseudoInverse = pinv_calc_.calculate(this->params_, this->damping_, this->jacobian_data_);
-    Eigen::MatrixXd qdots_out = jacobianPseudoInverse * inCartVelocities;
+    Eigen::MatrixXd pinv = pinv_calc_.calculate(this->params_, this->damping_, this->jacobian_data_);
+    Eigen::MatrixXd qdots_out = pinv * in_cart_velocities;
     return qdots_out;
 }
 

--- a/cob_twist_controller/src/constraint_solvers/solvers/weighted_least_norm_solver.cpp
+++ b/cob_twist_controller/src/constraint_solvers/solvers/weighted_least_norm_solver.cpp
@@ -43,10 +43,11 @@ Eigen::MatrixXd WeightedLeastNormSolver::solve(const Vector6d_t& in_cart_velocit
     Eigen::MatrixXd inv_root_W_WLN =  root_W_WLN.inverse();     // -> W^(-1/2)
 
     // SVD of JLA weighted Jacobian: Damping will be done later in calculatePinvJacobianBySVD for pseudo-inverse Jacobian with additional truncation etc.
-    Eigen::MatrixXd weighted_jacobian_pseudoinverse = pinv_calc_.calculate(this->params_, this->damping_, this->jacobian_data_ * inv_root_W_WLN);
+    Eigen::MatrixXd weighted_jacobian = this->jacobian_data_ * inv_root_W_WLN;
+    Eigen::MatrixXd pinv = pinv_calc_.calculate(this->params_, this->damping_, weighted_jacobian);
 
     // Take care: W^(1/2) * q_dot = weighted_pinv_J * x_dot -> One must consider the weighting!!!
-    Eigen::MatrixXd qdots_out = inv_root_W_WLN * weighted_jacobian_pseudoinverse * in_cart_velocities;
+    Eigen::MatrixXd qdots_out = inv_root_W_WLN * pinv * in_cart_velocities;
     return qdots_out;
 }
 
@@ -56,6 +57,6 @@ Eigen::MatrixXd WeightedLeastNormSolver::solve(const Vector6d_t& in_cart_velocit
 Eigen::MatrixXd WeightedLeastNormSolver::calculateWeighting(const JointStates& joint_states) const
 {
     uint32_t cols = this->jacobian_data_.cols();
-    Eigen::VectorXd output = Eigen::VectorXd::Ones(cols);
-    return output.asDiagonal();
+    Eigen::VectorXd weighting = Eigen::VectorXd::Ones(cols);
+    return weighting.asDiagonal();
 }

--- a/cob_twist_controller/src/constraint_solvers/solvers/wln_joint_limit_avoidance_solver.cpp
+++ b/cob_twist_controller/src/constraint_solvers/solvers/wln_joint_limit_avoidance_solver.cpp
@@ -41,14 +41,14 @@ Eigen::MatrixXd WLN_JointLimitAvoidanceSolver::calculateWeighting(const JointSta
     std::vector<double> limits_min = this->limiter_params_.limits_min;
     std::vector<double> limits_max = this->limiter_params_.limits_max;
     uint32_t cols = this->jacobian_data_.cols();
-    Eigen::VectorXd output = Eigen::VectorXd::Zero(cols);
+    Eigen::VectorXd weighting = Eigen::VectorXd::Zero(cols);
 
     KDL::JntArray q = joint_states.current_q_;
     KDL::JntArray q_dot = joint_states.current_q_dot_;
 
     for (uint32_t i = 0; i < cols ; ++i)
     {
-        output(i) = 1.0;    // in the else cases -> output always 1
+        weighting(i) = 1.0;    // in the else cases -> weighting always 1
         if (i < q.rows())
         {
             // See Chan paper ISSN 1042-296X [Page 288]
@@ -61,11 +61,11 @@ Eigen::MatrixXd WLN_JointLimitAvoidanceSolver::calculateWeighting(const JointSta
                 if (denominator != 0.0)
                 {
                     double partialPerformanceCriterion = fabs(nominator / denominator);
-                    output(i) = 1 + partialPerformanceCriterion;
+                    weighting(i) = 1 + partialPerformanceCriterion;
                 }
             }
         }
     }
 
-    return output.asDiagonal();
+    return weighting.asDiagonal();
 }


### PR DESCRIPTION
fixes #65 
might also solve #56 (?)
additionally, more consistent variable naming among solvers
- needs to be tested on hardware
- needs to be tested with (actual) constraints
