### PR TITLE
proper reset for ControllerInterfaceJointStates

### DIFF
--- a/cob_twist_controller/src/cob_twist_controller.cpp
+++ b/cob_twist_controller/src/cob_twist_controller.cpp
@@ -145,7 +145,7 @@ bool CobTwistController::initialize()
 
     odometry_sub_ = nh_.subscribe("base/odometry", 1, &CobTwistController::odometryCallback, this);
 
-    this->controller_interface_.reset(ControllerInterfaceBuilder::createControllerInterface(this->nh_, this->twist_controller_params_));
+    this->controller_interface_.reset(ControllerInterfaceBuilder::createControllerInterface(this->nh_, this->twist_controller_params_, this->joint_states_));
 
     /// publisher for visualizing current twist direction
     twist_direction_pub_ = nh_.advertise<visualization_msgs::Marker>("twist_direction", 1);
@@ -227,7 +227,7 @@ void CobTwistController::reconfigureCallback(cob_twist_controller::TwistControll
     twist_controller_params_.kinematic_extension = static_cast<KinematicExtensionTypes>(config.kinematic_extension);
     twist_controller_params_.extension_ratio = config.extension_ratio;
 
-    this->controller_interface_.reset(ControllerInterfaceBuilder::createControllerInterface(this->nh_, this->twist_controller_params_));
+    this->controller_interface_.reset(ControllerInterfaceBuilder::createControllerInterface(this->nh_, this->twist_controller_params_, this->joint_states_));
 
     p_inv_diff_kin_solver_->resetAll(this->twist_controller_params_);
 

--- a/cob_twist_controller/src/controller_interfaces/controller_interface.cpp
+++ b/cob_twist_controller/src/controller_interfaces/controller_interface.cpp
@@ -33,7 +33,8 @@
  * Static builder method to create controller interface based on given parameterization.
  */
 ControllerInterfaceBase* ControllerInterfaceBuilder::createControllerInterface(ros::NodeHandle& nh,
-                                                                               const TwistControllerParams& params)
+                                                                               const TwistControllerParams& params,
+                                                                               const JointStates& joint_states)
 {
     ControllerInterfaceBase* ib = NULL;
     switch (params.controller_interface)
@@ -48,7 +49,7 @@ ControllerInterfaceBase* ControllerInterfaceBuilder::createControllerInterface(r
             ib = new ControllerInterfaceTrajectory(nh, params);
             break;
         case JOINT_STATE_INTERFACE:
-            ib = new ControllerInterfaceJointStates(nh, params);
+            ib = new ControllerInterfaceJointStates(nh, params, joint_states);
             break;
         default:
             ROS_ERROR("ControllerInterface %d not defined! Using default: 'VELOCITY_INTERFACE'!", params.controller_interface);


### PR DESCRIPTION
problem was that it was always reset to (0.0,...,0.0) rather than keep current JointStates after using dynamic reconfigure.
