### PR TITLE
Configurable lookat offset and axis

### DIFF
--- a/cob_frame_tracker/cfg/FrameTracker.cfg
+++ b/cob_frame_tracker/cfg/FrameTracker.cfg
@@ -5,6 +5,7 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
+gen.add("enable_abortion_checking", bool_t,   0, "Enable abortion checks and publish_hold_twist",  True)
 gen.add("cart_min_dist_threshold_lin", double_t, 0, "Cartesian minimal distance for tracking lin", 0.2, 0.0, 0.5)
 gen.add("cart_min_dist_threshold_rot", double_t, 0, "Cartesian minimal distance for tracking rot", 0.2, 0.0, 0.5)
 gen.add("twist_dead_threshold_lin", double_t, 0, "Twist dead threshold lin", 0.05, 0.0, 0.5)

--- a/cob_frame_tracker/include/cob_frame_tracker/cob_frame_tracker.h
+++ b/cob_frame_tracker/include/cob_frame_tracker/cob_frame_tracker.h
@@ -176,6 +176,7 @@ private:
     double tracking_duration_;
     ros::Time tracking_start_time_;
 
+    bool enable_abortion_checking_;
     double cart_min_dist_threshold_lin_;
     double cart_min_dist_threshold_rot_;
     double twist_dead_threshold_lin_;

--- a/cob_frame_tracker/include/cob_frame_tracker/interactive_frame_target.h
+++ b/cob_frame_tracker/include/cob_frame_tracker/interactive_frame_target.h
@@ -81,7 +81,7 @@ private:
     ros::ServiceClient start_lookat_client_;
     ros::ServiceClient stop_client_;
 
-    void updateMarker();
+    void updateMarker(const std::string& frame);
     void sendTransform(const ros::TimerEvent& event);
     void startTracking( const visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback );
     void startLookat( const visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback );

--- a/cob_frame_tracker/src/cob_frame_tracker.cpp
+++ b/cob_frame_tracker/src/cob_frame_tracker.cpp
@@ -139,7 +139,7 @@ bool CobFrameTracker::initialize()
     lookat_focus_frame_ = "lookat_focus_frame";
 
     //ABORTION CRITERIA:
-    enable_abortion_checking_ = false;
+    enable_abortion_checking_ = true;
     cart_min_dist_threshold_lin_ = 0.01;
     cart_min_dist_threshold_rot_ = 0.01;
     twist_dead_threshold_lin_ = 0.05;

--- a/cob_frame_tracker/src/interactive_frame_target.cpp
+++ b/cob_frame_tracker/src/interactive_frame_target.cpp
@@ -38,7 +38,7 @@ bool InteractiveFrameTarget::initialize()
     if (nh_tracker.hasParam("update_rate"))
     {    nh_tracker.getParam("update_rate", update_rate_);    }
     else
-    {    update_rate_ = 68.0;    }    //hz
+    {    update_rate_ = 50.0;    }    //hz
 
     if (nh_.hasParam("chain_tip_link"))
     {

--- a/cob_frame_tracker/src/interactive_frame_target.cpp
+++ b/cob_frame_tracker/src/interactive_frame_target.cpp
@@ -232,23 +232,25 @@ bool InteractiveFrameTarget::initialize()
 void InteractiveFrameTarget::sendTransform(const ros::TimerEvent& event)
 {
     if(!tracking_ && !lookat_)
-    {    updateMarker();    }
+    {    updateMarker(tracking_frame_);    }
 
     target_pose_.stamp_ = ros::Time::now();
     target_pose_.child_frame_id_ = target_frame_;
     tf_broadcaster_.sendTransform(target_pose_);
 }
 
-void InteractiveFrameTarget::updateMarker()
+void InteractiveFrameTarget::updateMarker(const std::string& frame)
 {
     bool transform_available = false;
     while(!transform_available)
     {
-        try{
-            tf_listener_.lookupTransform(root_frame_, tracking_frame_, ros::Time(), target_pose_);
+        try
+        {
+            tf_listener_.lookupTransform(root_frame_, frame, ros::Time(), target_pose_);
             transform_available = true;
         }
-        catch (tf::TransformException& ex){
+        catch (tf::TransformException& ex)
+        {
             //ROS_WARN("IFT::updateMarker: Waiting for transform...(%s)",ex.what());
             ros::Duration(0.1).sleep();
         }
@@ -293,6 +295,9 @@ void InteractiveFrameTarget::startLookat( const visualization_msgs::InteractiveM
     if(success && srv.response.success)
     {
         ROS_INFO_STREAM("StartLookat successful: " << srv.response.message);
+
+        updateMarker("lookat_focus_frame");
+
         tracking_ = false;
         lookat_ = true;
     }

--- a/cob_twist_controller/CMakeLists.txt
+++ b/cob_twist_controller/CMakeLists.txt
@@ -62,6 +62,8 @@ add_executable(cob_twist_controller_node src/cob_twist_controller_node.cpp)
 add_dependencies(cob_twist_controller_node ${catkin_EXPORTED_TARGETS})
 target_link_libraries(cob_twist_controller_node twist_controller ${catkin_LIBRARIES} ${orocos_kdl_LIBRARIES})
 
+
+### DEBUG NODES ###
 add_executable(debug_trajectory_marker_node src/debug/debug_trajectory_marker_node.cpp)
 add_dependencies(debug_trajectory_marker_node ${catkin_EXPORTED_TARGETS})
 target_link_libraries(debug_trajectory_marker_node ${catkin_LIBRARIES})
@@ -69,7 +71,6 @@ target_link_libraries(debug_trajectory_marker_node ${catkin_LIBRARIES})
 add_executable(debug_evaluate_jointstates_node src/debug/debug_evaluate_jointstates_node.cpp)
 add_dependencies(debug_evaluate_jointstates_node ${catkin_EXPORTED_TARGETS})
 target_link_libraries(debug_evaluate_jointstates_node ${catkin_LIBRARIES} ${orocos_kdl_LIBRARIES})
-
 
 add_executable(test_moving_average_node src/debug/test_moving_average_node.cpp)
 add_dependencies(test_moving_average_node ${catkin_EXPORTED_TARGETS})
@@ -79,10 +80,20 @@ add_executable(test_simpson_integrator_node src/debug/test_simpson_integrator_no
 add_dependencies(test_simpson_integrator_node ${catkin_EXPORTED_TARGETS})
 target_link_libraries(test_simpson_integrator_node ${catkin_LIBRARIES})
 
+add_executable(test_trajectory_command_sine_node src/debug/test_trajectory_command_sine_node.cpp)
+add_dependencies(test_trajectory_command_sine_node ${catkin_EXPORTED_TARGETS})
+target_link_libraries(test_trajectory_command_sine_node ${catkin_LIBRARIES})
+
 roslint_cpp()
 
 ### INSTALL ###
-install(TARGETS cob_twist_controller_node damping_methods inv_calculations constraint_solvers limiters controller_interfaces kinematic_extensions inverse_differential_kinematics_solver twist_controller debug_trajectory_marker_node debug_evaluate_jointstates_node
+install(TARGETS cob_twist_controller_node damping_methods inv_calculations constraint_solvers limiters controller_interfaces kinematic_extensions inverse_differential_kinematics_solver twist_controller
+ ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+ LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+ RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(TARGETS debug_trajectory_marker_node debug_evaluate_jointstates_node test_moving_average_node test_simpson_integrator_node test_trajectory_command_sine_node
  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/cob_twist_controller/CMakeLists.txt
+++ b/cob_twist_controller/CMakeLists.txt
@@ -84,6 +84,10 @@ add_executable(test_trajectory_command_sine_node src/debug/test_trajectory_comma
 add_dependencies(test_trajectory_command_sine_node ${catkin_EXPORTED_TARGETS})
 target_link_libraries(test_trajectory_command_sine_node ${catkin_LIBRARIES})
 
+add_executable(test_forward_command_sine_node src/debug/test_forward_command_sine_node.cpp)
+add_dependencies(test_forward_command_sine_node ${catkin_EXPORTED_TARGETS})
+target_link_libraries(test_forward_command_sine_node ${catkin_LIBRARIES})
+
 roslint_cpp()
 
 ### INSTALL ###

--- a/cob_twist_controller/cfg/TwistController.cfg
+++ b/cob_twist_controller/cfg/TwistController.cfg
@@ -52,7 +52,8 @@ kinematic_extension_enum = gen.enum([
 
 # ==================================== Controller interfaces =================================================================================
 ctrl_interface = gen.add_group("Controller Interfaces", "ctrl_interface")
-ctrl_interface.add("controller_interface",     int_t,    0, "The controller interface to use", 0, None, None, edit_method=controller_interface_enum)
+ctrl_interface.add("controller_interface",   int_t,    0, "The controller interface to use", 0, None, None, edit_method=controller_interface_enum)
+ctrl_interface.add("integrator_smoothing",   double_t, 0, "The factor used for exponential smoothing during simpson integration)",  0.2, 0, 1)
 
 # ==================================== Damping and truncation (singular value adaption) ====================================================
 damp_trunc = gen.add_group("Damping and Truncation", "damping_truncation")
@@ -103,6 +104,6 @@ limits.add("max_vel_rot_base", double_t, 0, "Maximum rotational velocity to be c
 # ==================================== Parameters for kinematics extensions =====================================================
 kin_ext = gen.add_group("Kinematics Extension", "kin_ext")
 kin_ext.add("kinematic_extension",    int_t,    0, "Consider additional DoF", 0, None, None, edit_method=kinematic_extension_enum)
-kin_ext.add("extension_ratio",             double_t, 0, "Value for ratio between chain and extension",  0.01, 0.0, 1.0)
+kin_ext.add("extension_ratio",        double_t, 0, "Value for ratio between chain and extension",  0.01, 0.0, 1.0)
 
 exit(gen.generate(PACKAGE, "cob_twist_controller", "TwistController"))

--- a/cob_twist_controller/include/cob_twist_controller/cob_twist_controller_data_types.h
+++ b/cob_twist_controller/include/cob_twist_controller/cob_twist_controller_data_types.h
@@ -116,23 +116,23 @@ struct LookatOffset
 {
     LookatOffset() :
         lookat_axis_type(X_POSITIVE),
-        lookat_vec_x(0.0),
-        lookat_vec_y(0.0),
-        lookat_vec_z(0.0),
-        lookat_quat_x(0.0),
-        lookat_quat_y(0.0),
-        lookat_quat_z(0.0),
-        lookat_quat_w(1.0)
+        translation_x(0.0),
+        translation_y(0.0),
+        translation_z(0.0),
+        rotation_x(0.0),
+        rotation_y(0.0),
+        rotation_z(0.0),
+        rotation_w(1.0)
     {}
 
     LookatAxisTypes lookat_axis_type;
-    double lookat_vec_x;
-    double lookat_vec_y;
-    double lookat_vec_z;
-    double lookat_quat_x;
-    double lookat_quat_y;
-    double lookat_quat_z;
-    double lookat_quat_w;
+    double translation_x;
+    double translation_y;
+    double translation_z;
+    double rotation_x;
+    double rotation_y;
+    double rotation_z;
+    double rotation_w;
 };
 
 struct JointStates

--- a/cob_twist_controller/include/cob_twist_controller/cob_twist_controller_data_types.h
+++ b/cob_twist_controller/include/cob_twist_controller/cob_twist_controller_data_types.h
@@ -165,6 +165,7 @@ struct TwistControllerParams
     TwistControllerParams() :
         dof(0),
         controller_interface(VELOCITY_INTERFACE),
+        integrator_smoothing(0.2),
 
         numerical_filtering(false),
         damping_method(MANIPULABILITY),
@@ -206,6 +207,7 @@ struct TwistControllerParams
     std::string chain_tip_link;
 
     ControllerInterfaceTypes controller_interface;
+    double integrator_smoothing;
 
     bool numerical_filtering;
     DampingMethodTypes damping_method;

--- a/cob_twist_controller/include/cob_twist_controller/cob_twist_controller_data_types.h
+++ b/cob_twist_controller/include/cob_twist_controller/cob_twist_controller_data_types.h
@@ -102,6 +102,39 @@ enum ConstraintTypes
     JLA_INEQ,
 };
 
+enum LookatAxisTypes
+{
+    X_POSITIVE,
+    Y_POSITIVE,
+    Z_POSITIVE,
+    X_NEGATIVE,
+    Y_NEGATIVE,
+    Z_NEGATIVE,
+};
+
+struct LookatOffset
+{
+    LookatOffset() :
+        lookat_axis_type(X_POSITIVE),
+        lookat_vec_x(0.0),
+        lookat_vec_y(0.0),
+        lookat_vec_z(0.0),
+        lookat_quat_x(0.0),
+        lookat_quat_y(0.0),
+        lookat_quat_z(0.0),
+        lookat_quat_w(1.0)
+    {}
+
+    LookatAxisTypes lookat_axis_type;
+    double lookat_vec_x;
+    double lookat_vec_y;
+    double lookat_vec_z;
+    double lookat_quat_x;
+    double lookat_quat_y;
+    double lookat_quat_z;
+    double lookat_quat_w;
+};
+
 struct JointStates
 {
     KDL::JntArray current_q_;
@@ -237,6 +270,7 @@ struct TwistControllerParams
     LimiterParams limiter_params;
 
     KinematicExtensionTypes kinematic_extension;
+    LookatOffset lookat_offset;
     double extension_ratio;
 
     std::vector<std::string> frame_names;

--- a/cob_twist_controller/include/cob_twist_controller/controller_interfaces/controller_interface.h
+++ b/cob_twist_controller/include/cob_twist_controller/controller_interfaces/controller_interface.h
@@ -131,7 +131,8 @@ class ControllerInterfaceJointStates : public ControllerInterfacePositionBase
             js_msg_.position.clear();
             js_msg_.velocity.clear();
             js_msg_.effort.clear();
-            for(unsigned int i=0; i < joint_states.current_q_.rows(); i++)
+
+            for (unsigned int i=0; i < joint_states.current_q_.rows(); i++)
             {
                 js_msg_.position.push_back(joint_states.current_q_(i));
                 js_msg_.velocity.push_back(joint_states.current_q_dot_(i));

--- a/cob_twist_controller/include/cob_twist_controller/controller_interfaces/controller_interface.h
+++ b/cob_twist_controller/include/cob_twist_controller/controller_interfaces/controller_interface.h
@@ -138,7 +138,7 @@ class ControllerInterfaceJointStates : public ControllerInterfacePositionBase
                 js_msg_.effort.push_back(0.0);
             }
 
-            js_timer_ = nh.createTimer(ros::Duration(1/60.0), &ControllerInterfaceJointStates::publishJointState, this);
+            js_timer_ = nh.createTimer(ros::Duration(1/50.0), &ControllerInterfaceJointStates::publishJointState, this);
             js_timer_.start();
         }
 

--- a/cob_twist_controller/include/cob_twist_controller/controller_interfaces/controller_interface_base.h
+++ b/cob_twist_controller/include/cob_twist_controller/controller_interfaces/controller_interface_base.h
@@ -66,7 +66,7 @@ class ControllerInterfacePositionBase : public ControllerInterfaceBase
         : ControllerInterfaceBase(nh, params)
         {
             last_update_time_ = ros::Time(0.0);
-            integrator_.reset(new SimpsonIntegrator(params.dof));
+            integrator_.reset(new SimpsonIntegrator(params.dof, params.integrator_smoothing));
         }
 
         ~ControllerInterfacePositionBase() {}

--- a/cob_twist_controller/include/cob_twist_controller/controller_interfaces/controller_interface_base.h
+++ b/cob_twist_controller/include/cob_twist_controller/controller_interfaces/controller_interface_base.h
@@ -65,6 +65,7 @@ class ControllerInterfacePositionBase : public ControllerInterfaceBase
                                                  const TwistControllerParams& params)
         : ControllerInterfaceBase(nh, params)
         {
+            last_update_time_ = ros::Time(0.0);
             integrator_.reset(new SimpsonIntegrator(params.dof));
         }
 
@@ -76,12 +77,17 @@ class ControllerInterfacePositionBase : public ControllerInterfaceBase
         bool updateIntegration(const KDL::JntArray& q_dot_ik,
                                const KDL::JntArray& current_q)
         {
+            ros::Time now = ros::Time::now();
+            period_ = now - last_update_time_;
+            last_update_time_ = now;
             return integrator_->updateIntegration(q_dot_ik, current_q, pos, vel);
         }
 
     protected:
         boost::shared_ptr<SimpsonIntegrator> integrator_;
         std::vector<double> pos, vel;
+        ros::Time last_update_time_;
+        ros::Duration period_;
 };
 
 #endif  // COB_TWIST_CONTROLLER_CONTROLLER_INTERFACES_CONTROLLER_INTERFACE_BASE_H

--- a/cob_twist_controller/include/cob_twist_controller/controller_interfaces/controller_interface_base.h
+++ b/cob_twist_controller/include/cob_twist_controller/controller_interfaces/controller_interface_base.h
@@ -80,12 +80,12 @@ class ControllerInterfacePositionBase : public ControllerInterfaceBase
             ros::Time now = ros::Time::now();
             period_ = now - last_update_time_;
             last_update_time_ = now;
-            return integrator_->updateIntegration(q_dot_ik, current_q, pos, vel);
+            return integrator_->updateIntegration(q_dot_ik, current_q, pos_, vel_);
         }
 
     protected:
         boost::shared_ptr<SimpsonIntegrator> integrator_;
-        std::vector<double> pos, vel;
+        std::vector<double> pos_, vel_;
         ros::Time last_update_time_;
         ros::Duration period_;
 };

--- a/cob_twist_controller/include/cob_twist_controller/utils/simpson_integrator.h
+++ b/cob_twist_controller/include/cob_twist_controller/utils/simpson_integrator.h
@@ -43,8 +43,7 @@ class SimpsonIntegrator
         explicit SimpsonIntegrator(const uint8_t dof, const double integrator_smoothing = 0.2)
             : dof_(dof),
               integrator_smoothing_(integrator_smoothing),
-              last_update_time_(ros::Time(0.0)),
-              last_period_(ros::Duration(0.0))
+              last_update_time_(ros::Time(0.0))
         {
             for (uint8_t i = 0; i < dof_; i++)
             {
@@ -83,13 +82,13 @@ class SimpsonIntegrator
         {
             ros::Time now = ros::Time::now();
             ros::Duration period = now - last_update_time_;
+            last_update_time_ = now;
 
             bool value_valid = false;
             pos.clear();
             vel.clear();
 
             // ToDo: Test these conditions and find good thresholds
-            // if (period.toSec() > 2*last_period_.toSec())  // missed about a cycle
             if (period.toSec() > ros::Duration(0.5).toSec())  // missed about 'max_command_silence'
             {
                 ROS_WARN_STREAM("reset Integration: " << period.toSec());
@@ -157,9 +156,6 @@ class SimpsonIntegrator
                 vel_last_.push_back(q_dot_avg(i));
             }
 
-            last_update_time_ = now;
-            last_period_ = period;
-
             /// q_dot_ik_pub_.publish(q_dot_ik_msg);
             /// q_dot_avg_pub_.publish(q_dot_avg_msg);
             /// q_simpson_pub_.publish(q_simpson_msg);
@@ -175,7 +171,6 @@ class SimpsonIntegrator
         double integrator_smoothing_;
         std::vector<double> vel_last_, vel_before_last_;
         ros::Time last_update_time_;
-        ros::Duration last_period_;
 
         // debug
         /// ros::NodeHandle nh_;

--- a/cob_twist_controller/src/cob_twist_controller.cpp
+++ b/cob_twist_controller/src/cob_twist_controller.cpp
@@ -183,6 +183,7 @@ void CobTwistController::reconfigureCallback(cob_twist_controller::TwistControll
 {
     this->checkSolverAndConstraints(config);
     twist_controller_params_.controller_interface = static_cast<ControllerInterfaceTypes>(config.controller_interface);
+    twist_controller_params_.integrator_smoothing = config.integrator_smoothing;
 
     twist_controller_params_.numerical_filtering = config.numerical_filtering;
     twist_controller_params_.damping_method = static_cast<DampingMethodTypes>(config.damping_method);

--- a/cob_twist_controller/src/cob_twist_controller.cpp
+++ b/cob_twist_controller/src/cob_twist_controller.cpp
@@ -113,6 +113,18 @@ bool CobTwistController::initialize()
         }
     }
 
+    // Configure Lookat Extenstion (Offset and Axis) --- not dynamic-reconfigurable
+    int lookat_axis_type;
+    if (nh_twist.getParam("lookat_axis_type", lookat_axis_type))
+    {   twist_controller_params_.lookat_offset.lookat_axis_type = static_cast<LookatAxisTypes>(lookat_axis_type);   }
+    nh_twist.getParam("lookat_vec_x", twist_controller_params_.lookat_offset.lookat_vec_x);
+    nh_twist.getParam("lookat_vec_y", twist_controller_params_.lookat_offset.lookat_vec_y);
+    nh_twist.getParam("lookat_vec_z", twist_controller_params_.lookat_offset.lookat_vec_z);
+    nh_twist.getParam("lookat_quat_x", twist_controller_params_.lookat_offset.lookat_quat_x);
+    nh_twist.getParam("lookat_quat_y", twist_controller_params_.lookat_offset.lookat_quat_y);
+    nh_twist.getParam("lookat_quat_z", twist_controller_params_.lookat_offset.lookat_quat_z);
+    nh_twist.getParam("lookat_quat_w", twist_controller_params_.lookat_offset.lookat_quat_w);
+
     twist_controller_params_.frame_names.clear();
     for (uint16_t i = 0; i < chain_.getNrOfSegments(); ++i)
     {

--- a/cob_twist_controller/src/cob_twist_controller.cpp
+++ b/cob_twist_controller/src/cob_twist_controller.cpp
@@ -114,16 +114,28 @@ bool CobTwistController::initialize()
     }
 
     // Configure Lookat Extenstion (Offset and Axis) --- not dynamic-reconfigurable
-    int lookat_axis_type;
-    if (nh_twist.getParam("lookat_axis_type", lookat_axis_type))
-    {   twist_controller_params_.lookat_offset.lookat_axis_type = static_cast<LookatAxisTypes>(lookat_axis_type);   }
-    nh_twist.getParam("lookat_vec_x", twist_controller_params_.lookat_offset.lookat_vec_x);
-    nh_twist.getParam("lookat_vec_y", twist_controller_params_.lookat_offset.lookat_vec_y);
-    nh_twist.getParam("lookat_vec_z", twist_controller_params_.lookat_offset.lookat_vec_z);
-    nh_twist.getParam("lookat_quat_x", twist_controller_params_.lookat_offset.lookat_quat_x);
-    nh_twist.getParam("lookat_quat_y", twist_controller_params_.lookat_offset.lookat_quat_y);
-    nh_twist.getParam("lookat_quat_z", twist_controller_params_.lookat_offset.lookat_quat_z);
-    nh_twist.getParam("lookat_quat_w", twist_controller_params_.lookat_offset.lookat_quat_w);
+    if (nh_twist.hasParam("lookat_axis_type"))
+    {
+        int lookat_axis_type;
+        nh_twist.getParam("lookat_axis_type", lookat_axis_type);
+        twist_controller_params_.lookat_offset.lookat_axis_type = static_cast<LookatAxisTypes>(lookat_axis_type);
+    }
+    if (nh_twist.hasParam("lookat_offset"))
+    {
+        if (nh_twist.hasParam("lookat_offset/translation"))
+        {
+            twist_controller_params_.lookat_offset.translation_x = nh_twist.param("lookat_offset/translation/x", 0.0);
+            twist_controller_params_.lookat_offset.translation_y = nh_twist.param("lookat_offset/translation/y", 0.0);
+            twist_controller_params_.lookat_offset.translation_z = nh_twist.param("lookat_offset/translation/z", 0.0);
+        }
+        if (nh_twist.hasParam("lookat_offset/rotation"))
+        {
+            twist_controller_params_.lookat_offset.rotation_x = nh_twist.param("lookat_offset/rotation/x", 0.0);
+            twist_controller_params_.lookat_offset.rotation_y = nh_twist.param("lookat_offset/rotation/y", 0.0);
+            twist_controller_params_.lookat_offset.rotation_z = nh_twist.param("lookat_offset/rotation/z", 0.0);
+            twist_controller_params_.lookat_offset.rotation_w = nh_twist.param("lookat_offset/rotation/w", 1.0);
+        }
+    }
 
     twist_controller_params_.frame_names.clear();
     for (uint16_t i = 0; i < chain_.getNrOfSegments(); ++i)

--- a/cob_twist_controller/src/controller_interfaces/controller_interface.cpp
+++ b/cob_twist_controller/src/controller_interfaces/controller_interface.cpp
@@ -91,7 +91,7 @@ inline void ControllerInterfacePosition::processResult(const KDL::JntArray& q_do
     {
         /// publish to interface
         std_msgs::Float64MultiArray pos_msg;
-        pos_msg.data = pos;
+        pos_msg.data = pos_;
         pub_.publish(pos_msg);
     }
 }
@@ -108,8 +108,8 @@ inline void ControllerInterfaceTrajectory::processResult(const KDL::JntArray& q_
     if (updateIntegration(q_dot_ik, current_q))
     {
         trajectory_msgs::JointTrajectoryPoint traj_point;
-        traj_point.positions = pos;
-        // traj_point.velocities = vel;
+        traj_point.positions = pos_;
+        // traj_point.velocities = vel_;
         // traj_point.accelerations.assign(params_.dof, 0.0);
         // traj_point.effort.assign(params_.dof, 0.0);
         traj_point.time_from_start = period_;
@@ -137,8 +137,8 @@ inline void ControllerInterfaceJointStates::processResult(const KDL::JntArray& q
     {
         /// update JointState
         boost::mutex::scoped_lock lock(mutex_);
-        js_msg_.position = pos;
-        js_msg_.velocity = vel;
+        js_msg_.position = pos_;
+        js_msg_.velocity = vel_;
 
         /// publishing takes place in separate thread
     }

--- a/cob_twist_controller/src/controller_interfaces/controller_interface.cpp
+++ b/cob_twist_controller/src/controller_interfaces/controller_interface.cpp
@@ -112,10 +112,10 @@ inline void ControllerInterfaceTrajectory::processResult(const KDL::JntArray& q_
         // traj_point.velocities = vel;
         // traj_point.accelerations.assign(params_.dof, 0.0);
         // traj_point.effort.assign(params_.dof, 0.0);
-        traj_point.time_from_start = ros::Duration(0.05);  // ToDo: find good value
+        traj_point.time_from_start = period_;
 
         trajectory_msgs::JointTrajectory traj_msg;
-        traj_msg.header.stamp = ros::Time::now();
+        // traj_msg.header.stamp = ros::Time::now();
         traj_msg.joint_names = params_.joints;
         traj_msg.points.push_back(traj_point);
 

--- a/cob_twist_controller/src/debug/test_forward_command_sine_node.cpp
+++ b/cob_twist_controller/src/debug/test_forward_command_sine_node.cpp
@@ -1,0 +1,70 @@
+#include <vector>
+#include <string>
+
+#include <ros/ros.h>
+#include <std_msgs/Float64MultiArray.h>
+
+class ForwardCommandExecutionTester
+{
+public:
+    ForwardCommandExecutionTester()
+    {
+        dof_ = 2;
+        idx_ = 1;
+
+        output_pub_ = nh_.advertise<std_msgs::Float64MultiArray>("/torso/joint_group_interpol_position_controller/command", 1);
+
+        ros::Duration(1.0).sleep();
+    }
+
+
+    ~ForwardCommandExecutionTester()
+    {}
+
+    void run()
+    {
+        ros::Rate r(100.0);
+
+        ros::Time time = ros::Time::now();
+        ros::Time start_time = time;
+        double x = 0.0;
+
+        double a = 0.6, b = 0.4, c = 0, d = 0;      // torso_2dof
+        
+        std_msgs::Float64MultiArray command_msg;
+        command_msg.data.assign(dof_, 0.0);
+
+        while (ros::ok())
+        {
+            time = ros::Time::now();
+            x = (time - start_time).toSec();
+            
+            double vel = a*sin(b*x+c) + d;
+            
+            command_msg.data[idx_] = vel;
+            
+            output_pub_.publish(command_msg);
+            
+            ros::spinOnce();
+            r.sleep();
+        }
+    }
+
+
+    ros::NodeHandle nh_;
+    ros::Publisher output_pub_;
+    unsigned int dof_;
+    unsigned int idx_;
+};
+
+
+
+int main(int argc, char **argv)
+{
+    ros::init(argc, argv, "test_forward_command_execution_node");
+
+    ForwardCommandExecutionTester fcet;
+    fcet.run();
+    ros::spin();
+    return 0;
+}

--- a/cob_twist_controller/src/debug/test_trajectory_command_sine_node.cpp
+++ b/cob_twist_controller/src/debug/test_trajectory_command_sine_node.cpp
@@ -77,7 +77,7 @@ public:
             time = ros::Time::now();
             period = time - last_update_time;
             last_update_time = time;
-            x = x = time.toSec() - start_time.toSec();
+            x = time.toSec() - start_time.toSec();
 
             std::vector<double> next_q;
             std::vector<double> next_q_dot;

--- a/cob_twist_controller/src/debug/test_trajectory_command_sine_node.cpp
+++ b/cob_twist_controller/src/debug/test_trajectory_command_sine_node.cpp
@@ -1,0 +1,163 @@
+#include <vector>
+#include <ros/ros.h>
+#include <std_msgs/Float64.h>
+#include <trajectory_msgs/JointTrajectory.h>
+#include <kdl/jntarray.hpp>
+#include <cob_twist_controller/utils/simpson_integrator.h>
+
+class TrajectoryCommandExecutionTester
+{
+public:
+    TrajectoryCommandExecutionTester()
+    {
+        dof_ = 2;
+        idx_ = 0;
+
+        q_.resize(dof_);
+        KDL::SetToZero(q_);
+        q_dot_.resize(dof_);
+        KDL::SetToZero(q_dot_);
+        simpson_q_.resize(dof_);
+        KDL::SetToZero(simpson_q_);
+        euler_q_.resize(dof_);
+        KDL::SetToZero(euler_q_);
+        derived_simpson_q_dot_.resize(dof_);
+        KDL::SetToZero(derived_simpson_q_dot_);
+
+        integrator_.reset(new SimpsonIntegrator(dof_));
+        trajectory_pub_ = nh_.advertise<trajectory_msgs::JointTrajectory>("joint_trajectory_controller/command", 1);
+
+        output_q_pub_ = nh_.advertise<std_msgs::Float64>("integrator_debug/q", 1);
+        output_q_dot_pub_ = nh_.advertise<std_msgs::Float64>("integrator_debug/q_dot", 1);
+        output_simpson_q_pub_ = nh_.advertise<std_msgs::Float64>("integrator_debug/simpson_q", 1);
+        output_euler_q_pub_ = nh_.advertise<std_msgs::Float64>("integrator_debug/euler_q", 1);
+        output_derived_simpson_q_dot_pub_ = nh_.advertise<std_msgs::Float64>("integrator_debug/derived_simpson_q_dot", 1);
+        
+        ros::Duration(1.0).sleep();
+    }
+
+
+    ~TrajectoryCommandExecutionTester()
+    {}
+
+    void run()
+    {
+        ros::Rate r(100.0);
+
+        ros::Time time = ros::Time::now();
+        ros::Time last_update_time = time;
+        ros::Duration period = time - last_update_time;
+        ros::Time start_time = time;
+        double x = time.toSec() - start_time.toSec();
+        double old_pos = -99;
+
+        //double a = 0.6, b = 1.0, c = 0, d = 0;    //lwa4d
+        double a = 0.6, b = 0.4, c = 0, d = 0;      //torso_2dof
+        euler_q_(idx_) = a*sin(b*x+c) + d;          // correct initial value
+        
+        trajectory_msgs::JointTrajectoryPoint traj_point;
+        traj_point.positions.assign(dof_,0.0);
+        // traj_point.velocities.assign(dof_,0.0);
+
+        std::vector<std::string> joint_names;
+        // joint_names.push_back("arm_1_joint");
+        // joint_names.push_back("arm_2_joint");
+        // joint_names.push_back("arm_3_joint");
+        // joint_names.push_back("arm_4_joint");
+        // joint_names.push_back("arm_5_joint");
+        // joint_names.push_back("arm_6_joint");
+        // joint_names.push_back("arm_7_joint");
+        joint_names.push_back("torso_2_joint");
+        joint_names.push_back("torso_3_joint");
+
+        while(ros::ok())
+        {
+            time = ros::Time::now();
+            period = time - last_update_time;
+            last_update_time = time;
+            x = x = time.toSec() - start_time.toSec();
+
+            std::vector<double> next_q;
+            std::vector<double> next_q_dot;
+
+            q_(idx_)     = a*sin(b*x+c) + d;
+            q_dot_(idx_) = a*b*cos(b*x+c);
+
+            if (integrator_->updateIntegration(q_dot_, q_, next_q, next_q_dot))
+            {
+                simpson_q_(idx_) = next_q[idx_];
+                // q_dot_(idx_) = next_q_dot[idx_];
+            }
+
+            euler_q_(idx_) += q_dot_(idx_) * period.toSec();
+
+            traj_point.positions[idx_] = q_(idx_);
+            // traj_point.velocities[idx_] = q_dot_(idx_);
+            // traj_point.time_from_start = ros::Duration(0.5);             // should be as small as possible
+            traj_point.time_from_start = ros::Duration(period.toSec());     // seems to be a good value
+            // traj_point.time_from_start = ros::Duration(0.1 * period.toSec());  // does not make a difference anymore
+            ////// time_from_start should be as small as possible, however, setting it to none is not possible (trajectory point being dropped by controller due to occuring in the past)
+
+            trajectory_msgs::JointTrajectory traj_msg;
+            traj_msg.points.push_back(traj_point);
+            traj_msg.joint_names = joint_names;
+            //traj_msg.header.stamp = ros::Time::now();     //now or none - does not make a difference
+
+
+            std_msgs::Float64 q_msg;       //cos
+            q_msg.data = q_(idx_);
+            std_msgs::Float64 q_dot_msg;   //sin
+            q_dot_msg.data = q_dot_(idx_);
+            std_msgs::Float64 simpson_q_msg;
+            simpson_q_msg.data = simpson_q_(idx_);
+            std_msgs::Float64 euler_q_msg;
+            euler_q_msg.data = euler_q_(idx_);
+            std_msgs::Float64 derived_simpson_q_dot_msg;
+            derived_simpson_q_dot_msg.data = derived_simpson_q_dot_(idx_);
+
+            output_q_pub_.publish(q_msg);
+            output_q_dot_pub_.publish(q_dot_msg);
+            output_simpson_q_pub_.publish(simpson_q_msg);
+            output_euler_q_pub_.publish(euler_q_msg);
+            output_derived_simpson_q_dot_pub_.publish(derived_simpson_q_dot_msg);
+            
+            trajectory_pub_.publish(traj_msg);
+
+            ros::spinOnce();
+            r.sleep();
+        }
+    }
+
+
+    ros::NodeHandle nh_;
+    ros::Publisher trajectory_pub_;
+
+    ros::Publisher output_q_pub_;
+    ros::Publisher output_q_dot_pub_;
+    ros::Publisher output_simpson_q_pub_;
+    ros::Publisher output_euler_q_pub_;
+    ros::Publisher output_derived_simpson_q_dot_pub_;
+
+    KDL::JntArray q_;
+    KDL::JntArray q_dot_;
+    KDL::JntArray simpson_q_;
+    KDL::JntArray euler_q_;
+    KDL::JntArray derived_simpson_q_dot_;
+
+    boost::shared_ptr<SimpsonIntegrator> integrator_;
+
+    unsigned int dof_;
+    unsigned int idx_;
+};
+
+
+
+int main(int argc, char **argv)
+{
+    ros::init(argc, argv, "test_trajectory_command_execution_node");
+
+    TrajectoryCommandExecutionTester tcet;
+    tcet.run();
+    ros::spin();
+    return 0;
+}

--- a/cob_twist_controller/src/debug/test_trajectory_command_sine_node.cpp
+++ b/cob_twist_controller/src/debug/test_trajectory_command_sine_node.cpp
@@ -1,4 +1,6 @@
 #include <vector>
+#include <string>
+
 #include <ros/ros.h>
 #include <std_msgs/Float64.h>
 #include <trajectory_msgs/JointTrajectory.h>
@@ -32,7 +34,7 @@ public:
         output_simpson_q_pub_ = nh_.advertise<std_msgs::Float64>("integrator_debug/simpson_q", 1);
         output_euler_q_pub_ = nh_.advertise<std_msgs::Float64>("integrator_debug/euler_q", 1);
         output_derived_simpson_q_dot_pub_ = nh_.advertise<std_msgs::Float64>("integrator_debug/derived_simpson_q_dot", 1);
-        
+
         ros::Duration(1.0).sleep();
     }
 
@@ -51,10 +53,10 @@ public:
         double x = time.toSec() - start_time.toSec();
         double old_pos = -99;
 
-        //double a = 0.6, b = 1.0, c = 0, d = 0;    //lwa4d
-        double a = 0.6, b = 0.4, c = 0, d = 0;      //torso_2dof
+        //double a = 0.6, b = 1.0, c = 0, d = 0;    // lwa4d
+        double a = 0.6, b = 0.4, c = 0, d = 0;      // torso_2dof
         euler_q_(idx_) = a*sin(b*x+c) + d;          // correct initial value
-        
+
         trajectory_msgs::JointTrajectoryPoint traj_point;
         traj_point.positions.assign(dof_,0.0);
         // traj_point.velocities.assign(dof_,0.0);
@@ -70,7 +72,7 @@ public:
         joint_names.push_back("torso_2_joint");
         joint_names.push_back("torso_3_joint");
 
-        while(ros::ok())
+        while (ros::ok())
         {
             time = ros::Time::now();
             period = time - last_update_time;
@@ -101,12 +103,12 @@ public:
             trajectory_msgs::JointTrajectory traj_msg;
             traj_msg.points.push_back(traj_point);
             traj_msg.joint_names = joint_names;
-            //traj_msg.header.stamp = ros::Time::now();     //now or none - does not make a difference
+            // traj_msg.header.stamp = ros::Time::now();     //now or none - does not make a difference
 
 
-            std_msgs::Float64 q_msg;       //cos
+            std_msgs::Float64 q_msg;       // cos
             q_msg.data = q_(idx_);
-            std_msgs::Float64 q_dot_msg;   //sin
+            std_msgs::Float64 q_dot_msg;   // sin
             q_dot_msg.data = q_dot_(idx_);
             std_msgs::Float64 simpson_q_msg;
             simpson_q_msg.data = simpson_q_(idx_);
@@ -120,7 +122,7 @@ public:
             output_simpson_q_pub_.publish(simpson_q_msg);
             output_euler_q_pub_.publish(euler_q_msg);
             output_derived_simpson_q_dot_pub_.publish(derived_simpson_q_dot_msg);
-            
+
             trajectory_pub_.publish(traj_msg);
 
             ros::spinOnce();

--- a/cob_twist_controller/src/kinematic_extensions/kinematic_extension_lookat.cpp
+++ b/cob_twist_controller/src/kinematic_extensions/kinematic_extension_lookat.cpp
@@ -53,9 +53,39 @@ bool KinematicExtensionLookat::initExtension()
     }
 
     /// ToDo: orientation of lin_AXIS should be determined by a parameter
-    KDL::Vector lookat_lin_axis(1.0, 0.0, 0.0);
+    KDL::Vector lookat_lin_axis(0.0, 0.0, 0.0);
+    switch (params_.lookat_offset.lookat_axis_type)
+    {
+        case X_POSITIVE:
+            lookat_lin_axis.x(1.0);
+            break;
+        case Y_POSITIVE:
+            lookat_lin_axis.y(1.0);
+            break;
+        case Z_POSITIVE:
+            lookat_lin_axis.z(1.0);
+            break;
+        case X_NEGATIVE:
+            lookat_lin_axis.x(-1.0);
+            break;
+        case Y_NEGATIVE:
+            lookat_lin_axis.y(-1.0);
+            break;
+        case Z_NEGATIVE:
+            lookat_lin_axis.z(-1.0);
+            break;
+        default:
+            ROS_ERROR("LookatAxisType %d not defined! Using default: 'X_POSITIVE'!", params_.lookat_offset.lookat_axis_type);
+            lookat_lin_axis.x(1.0);
+            break;
+    }
     KDL::Joint lookat_lin_joint("lookat_lin_joint", KDL::Vector(), lookat_lin_axis, KDL::Joint::TransAxis);
-    KDL::Segment lookat_rotx_link("lookat_rotx_link", lookat_lin_joint);
+
+    KDL::Frame offset;
+    offset.p = KDL::Vector(params_.lookat_offset.lookat_vec_x, params_.lookat_offset.lookat_vec_y, params_.lookat_offset.lookat_vec_z);
+    offset.M = KDL::Rotation::Quaternion(params_.lookat_offset.lookat_quat_x, params_.lookat_offset.lookat_quat_y, params_.lookat_offset.lookat_quat_z, params_.lookat_offset.lookat_quat_w);
+
+    KDL::Segment lookat_rotx_link("lookat_rotx_link", lookat_lin_joint, offset);
     chain_ext_.addSegment(lookat_rotx_link);
     limits_ext_max_.push_back(std::numeric_limits<double>::max());
     limits_ext_min_.push_back(-params_.limiter_params.limits_tolerance);

--- a/cob_twist_controller/src/kinematic_extensions/kinematic_extension_lookat.cpp
+++ b/cob_twist_controller/src/kinematic_extensions/kinematic_extension_lookat.cpp
@@ -82,8 +82,8 @@ bool KinematicExtensionLookat::initExtension()
     KDL::Joint lookat_lin_joint("lookat_lin_joint", KDL::Vector(), lookat_lin_axis, KDL::Joint::TransAxis);
 
     KDL::Frame offset;
-    offset.p = KDL::Vector(params_.lookat_offset.lookat_vec_x, params_.lookat_offset.lookat_vec_y, params_.lookat_offset.lookat_vec_z);
-    offset.M = KDL::Rotation::Quaternion(params_.lookat_offset.lookat_quat_x, params_.lookat_offset.lookat_quat_y, params_.lookat_offset.lookat_quat_z, params_.lookat_offset.lookat_quat_w);
+    offset.p = KDL::Vector(params_.lookat_offset.translation_x, params_.lookat_offset.translation_y, params_.lookat_offset.translation_z);
+    offset.M = KDL::Rotation::Quaternion(params_.lookat_offset.rotation_x, params_.lookat_offset.rotation_y, params_.lookat_offset.rotation_z, params_.lookat_offset.rotation_w);
 
     KDL::Segment lookat_rotx_link("lookat_rotx_link", lookat_lin_joint, offset);
     chain_ext_.addSegment(lookat_rotx_link);

--- a/cob_twist_controller/src/kinematic_extensions/kinematic_extension_lookat.cpp
+++ b/cob_twist_controller/src/kinematic_extensions/kinematic_extension_lookat.cpp
@@ -89,7 +89,8 @@ bool KinematicExtensionLookat::initExtension()
     chain_ext_.addSegment(lookat_rotx_link);
     limits_ext_max_.push_back(std::numeric_limits<double>::max());
     limits_ext_min_.push_back(-params_.limiter_params.limits_tolerance);
-    limits_ext_vel_.push_back(std::numeric_limits<double>::max());
+    // limits_ext_vel_.push_back(std::numeric_limits<double>::max());
+    limits_ext_vel_.push_back(1.0);
     limits_ext_acc_.push_back(std::numeric_limits<double>::max());
 
     KDL::Vector lookat_rotx_axis(1.0, 0.0, 0.0);
@@ -98,7 +99,8 @@ bool KinematicExtensionLookat::initExtension()
     chain_ext_.addSegment(lookat_roty_link);
     limits_ext_max_.push_back(M_PI);
     limits_ext_min_.push_back(-M_PI);
-    limits_ext_vel_.push_back(std::numeric_limits<double>::max());
+    // limits_ext_vel_.push_back(std::numeric_limits<double>::max());
+    limits_ext_vel_.push_back(M_PI);
     limits_ext_acc_.push_back(std::numeric_limits<double>::max());
 
     KDL::Vector lookat_roty_axis(0.0, 1.0, 0.0);
@@ -107,7 +109,8 @@ bool KinematicExtensionLookat::initExtension()
     chain_ext_.addSegment(lookat_rotz_link);
     limits_ext_max_.push_back(M_PI);
     limits_ext_min_.push_back(-M_PI);
-    limits_ext_vel_.push_back(std::numeric_limits<double>::max());
+    // limits_ext_vel_.push_back(std::numeric_limits<double>::max());
+    limits_ext_vel_.push_back(M_PI);
     limits_ext_acc_.push_back(std::numeric_limits<double>::max());
 
     KDL::Vector lookat_rotz_axis(0.0, 0.0, 1.0);
@@ -116,7 +119,8 @@ bool KinematicExtensionLookat::initExtension()
     chain_ext_.addSegment(lookat_focus_frame);
     limits_ext_max_.push_back(M_PI);
     limits_ext_min_.push_back(-M_PI);
-    limits_ext_vel_.push_back(std::numeric_limits<double>::max());
+    // limits_ext_vel_.push_back(std::numeric_limits<double>::max());
+    limits_ext_vel_.push_back(M_PI);
     limits_ext_acc_.push_back(std::numeric_limits<double>::max());
 
     chain_full_ = chain_main;
@@ -135,7 +139,7 @@ bool KinematicExtensionLookat::initExtension()
     this->joint_states_ext_.current_q_dot_.resize(ext_dof_);
     KDL::SetToZero(this->joint_states_ext_.current_q_dot_);
 
-    integrator_.reset(new SimpsonIntegrator(ext_dof_));
+    integrator_.reset(new SimpsonIntegrator(ext_dof_, 0.2));  // default smoothing: 0.2
 
     timer_ = nh_.createTimer(ros::Duration(1/100.0), &KinematicExtensionLookat::broadcastFocusFrame, this);
     timer_.start();


### PR DESCRIPTION
includes #82 
fixes #81 

allows to configure the lookat extension, i.e. specify an offset translation and rotation as well as specify the lookat_lin_axis

example configuration (see https://github.com/ipa-fxm/cob_robots/commit/e627732d7fed4b4605f59bab800ccfe75a99d0f1):

```
lookat_axis_type: 0   #X_POSITIVE 0, Y_POSITIVE 1, Z_POSITIVE 2, X_NEGATIVE 3, Y_NEGATIVE 4, Z_NEGATIVE 5
lookat_offset: {translation: {x: 0.000, y: -0.000, z: 0.532}, rotation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}}
```
