### PR TITLE
configurable odometry_controller

### DIFF
--- a/cob_omni_drive_controller/include/cob_omni_drive_controller/OdometryTracker.h
+++ b/cob_omni_drive_controller/include/cob_omni_drive_controller/OdometryTracker.h
@@ -49,7 +49,7 @@ class OdometryTracker{
     nav_msgs::Odometry odom_;
     double theta_rob_rad_;
 public:
-    OdometryTracker(const std::string &from = "/wheelodom", const std::string &to = "/base_footprint" , double cov_pose = 0.1, double cov_twist = 0.1) {
+    OdometryTracker(const std::string &from = "/odom_wheel", const std::string &to = "/base_footprint" , double cov_pose = 0.1, double cov_twist = 0.1) {
         odom_.header.frame_id = from;
         odom_.child_frame_id = to;
         for(int i = 0; i < 6; i++){

--- a/cob_omni_drive_controller/include/cob_omni_drive_controller/OdometryTracker.h
+++ b/cob_omni_drive_controller/include/cob_omni_drive_controller/OdometryTracker.h
@@ -49,7 +49,7 @@ class OdometryTracker{
     nav_msgs::Odometry odom_;
     double theta_rob_rad_;
 public:
-    OdometryTracker(const std::string &from = "/odom_wheel", const std::string &to = "/base_footprint" , double cov_pose = 0.1, double cov_twist = 0.1) {
+    OdometryTracker(const std::string &from = "odom", const std::string &to = "base_footprint" , double cov_pose = 0.1, double cov_twist = 0.1) {
         odom_.header.frame_id = from;
         odom_.child_frame_id = to;
         for(int i = 0; i < 6; i++){

--- a/cob_omni_drive_controller/src/odom_plugin.cpp
+++ b/cob_omni_drive_controller/src/odom_plugin.cpp
@@ -35,7 +35,12 @@ public:
             return false;
         }
 
-        odom_tracker_.reset(new OdometryTracker);
+        const std::string frame_id = controller_nh.param("frame_id", std::string("/odom_wheel"));
+        const std::string child_frame_id = controller_nh.param("child_frame_id", std::string("/base_footprint"));
+        const double cov_pose = controller_nh.param("cov_pose", 0.1);
+        const double cov_twist = controller_nh.param("cov_twist", 0.1);
+
+        odom_tracker_.reset(new OdometryTracker(frame_id, child_frame_id, cov_pose, cov_twist));
         odom_ = odom_tracker_->getOdometry();
 
         topic_pub_odometry_ = controller_nh.advertise<nav_msgs::Odometry>("odometry", 1);
@@ -44,8 +49,8 @@ public:
         controller_nh.getParam("broadcast_tf", broadcast_tf);
 
         if(broadcast_tf){
-            odom_tf_.header.frame_id = "/odom_combined";
-            odom_tf_.child_frame_id = "/base_footprint";
+            odom_tf_.header.frame_id = frame_id;
+            odom_tf_.child_frame_id = child_frame_id;
             tf_broadcast_odometry_.reset(new tf::TransformBroadcaster);
         }
 
@@ -99,7 +104,7 @@ private:
     UndercarriageGeom::PlatformState platform_state_;
 
     ros::Publisher topic_pub_odometry_;                 // calculated (measured) velocity, rotation and pose (odometry-based) for the robot
-    ros::ServiceServer service_reset_;			// service to reset odometry to zero
+    ros::ServiceServer service_reset_;                  // service to reset odometry to zero
 
     boost::scoped_ptr<tf::TransformBroadcaster> tf_broadcast_odometry_;    // according transformation for the tf broadcaster
     boost::scoped_ptr<OdometryTracker> odom_tracker_;

--- a/cob_omni_drive_controller/src/odom_plugin.cpp
+++ b/cob_omni_drive_controller/src/odom_plugin.cpp
@@ -35,8 +35,8 @@ public:
             return false;
         }
 
-        const std::string frame_id = controller_nh.param("frame_id", std::string("/odom_wheel"));
-        const std::string child_frame_id = controller_nh.param("child_frame_id", std::string("/base_footprint"));
+        const std::string frame_id = controller_nh.param("frame_id", std::string("odom"));
+        const std::string child_frame_id = controller_nh.param("child_frame_id", std::string("base_footprint"));
         const double cov_pose = controller_nh.param("cov_pose", 0.1);
         const double cov_twist = controller_nh.param("cov_twist", 0.1);
 

--- a/cob_undercarriage_ctrl_node/src/cob_undercarriage_ctrl_new.cpp
+++ b/cob_undercarriage_ctrl_node/src/cob_undercarriage_ctrl_new.cpp
@@ -131,7 +131,7 @@ class NodeClass
 
     // Constructor
     NodeClass()
-    : ucar_ctrl_(0), odom_tracker_(new OdometryTracker)
+    : ucar_ctrl_(0)
     {
       // initialization of variables
       is_initialized_bool_ = false;
@@ -186,6 +186,13 @@ class NodeClass
       {
         n.getParam("broadcast_tf", broadcast_tf_);
       }
+
+      const std::string frame_id = n.param("frame_id", std::string("odom"));
+      const std::string child_frame_id = n.param("child_frame_id", std::string("base_footprint"));
+      const double cov_pose = n.param("cov_pose", 0.1);
+      const double cov_twist = n.param("cov_twist", 0.1);
+
+      odom_tracker_ = new OdometryTracker(frame_id, child_frame_id, cov_pose, cov_twist);
 
      // vector of wheels
      std::vector<UndercarriageCtrl::WheelParams> wps;


### PR DESCRIPTION
fixes #62 

I chose to set the `frame_id` to "odom_wheel" by default because it's the odometry controller with input from the wheels only. "odom_combined" would be coming from a node combining odometry data from wheels as well as e.g. GPS or alike....
However, as "odom_combined" is the frame we use most of the time, we would need to set (at least) the `frame_id` parameter in all the `base_controller.yaml`...

(BTW, I vote for "odom_wheel" vs. "wheelodom" as it is more consistent with "odom_combined")

@ipa-mdl @ipa-mig please provide input!
