### PR TITLE
verify position limit scaling factor

### DIFF
--- a/cob_twist_controller/include/cob_twist_controller/limiters/limiter.h
+++ b/cob_twist_controller/include/cob_twist_controller/limiters/limiter.h
@@ -33,7 +33,7 @@
 
 #include "cob_twist_controller/limiters/limiter_base.h"
 
-#define LIMIT_SAFETY_THRESHOLD 0.5 //[rad] -> 28°
+#define LIMIT_SAFETY_THRESHOLD 0.1/180.0*M_PI
 
 /* BEGIN LimiterContainer *******************************************************************************/
 /// Container for limiters, implementing interface methods.


### PR DESCRIPTION
I made some experiments regarding the behavior of the position scaling limiters:
beside some minor inconsistencies (fixed in this PR) the behavior is as expected!

Plot shows torso being moved (via Twist with `angular/z` of `-0.5`) towards the limit of `torso_3_joint` which is `-6.2831` [rad] in the URDF and the position limiters (`tolerance` of limiter is set to `45.0` [°] => tolerance threshold where it starts to scale is `-5.5` [rad]) properly scale down the `q_dot_ik` solution:

![pos_limit_scaling](https://cloud.githubusercontent.com/assets/508006/13436209/73834d70-dfde-11e5-98e1-64f6e2d009fb.png)
