### PR TITLE
Fix cob4 torso extension interface

### DIFF
--- a/cob_control_mode_adapter/src/cob_control_mode_adapter_node.cpp
+++ b/cob_control_mode_adapter/src/cob_control_mode_adapter_node.cpp
@@ -16,15 +16,12 @@ public:
         current_controller_names_.clear();
         traj_controller_names_.clear();
         pos_controller_names_.clear();
-        interpol_pos_controller_names_.clear();
         vel_controller_names_.clear();
         last_pos_command_ = ros::Time();
-        last_interpol_pos_command_ = ros::Time();
         last_vel_command_ = ros::Time();
 
         has_traj_controller_ = false;
         has_pos_controller_ = false;
-        has_interpol_pos_controller_ = false;
         has_vel_controller_ = false;
 
         current_control_mode_ = NONE;
@@ -87,13 +84,6 @@ public:
             ROS_DEBUG_STREAM(nh_.getNamespace() << " supports 'joint_group_position_controller'");
         }
 
-        if(nh_.hasParam("joint_group_interpol_position_controller"))
-        {
-            has_interpol_pos_controller_ = true;
-            interpol_pos_controller_names_.push_back("joint_group_interpol_position_controller");
-            ROS_DEBUG_STREAM(nh_.getNamespace() << " supports 'joint_group_interpol_position_controller'");
-        }
-
         if(nh_.hasParam("joint_group_velocity_controller"))
         {
             has_vel_controller_ = true;
@@ -116,14 +106,6 @@ public:
                 success = loadController(pos_controller_names_[i]);
             }
             cmd_pos_sub_ = nh_.subscribe("joint_group_position_controller/command", 1, &CobControlModeAdapter::cmd_pos_cb, this);
-        }
-        if(has_interpol_pos_controller_)
-        {
-            for (unsigned int i=0; i<interpol_pos_controller_names_.size(); i++)
-            {
-                success = loadController(interpol_pos_controller_names_[i]);
-            }
-            cmd_interpol_pos_sub_ = nh_.subscribe("joint_group_interpol_position_controller/command", 1, &CobControlModeAdapter::cmd_interpol_pos_cb, this);
         }
         if(has_vel_controller_)
         {
@@ -227,12 +209,6 @@ public:
         last_pos_command_ = ros::Time::now();
     }
 
-    void cmd_interpol_pos_cb(const std_msgs::Float64MultiArray::ConstPtr& msg)
-    {
-        boost::mutex::scoped_lock lock(mutex_);
-        last_interpol_pos_command_ = ros::Time::now();
-    }
-
     void cmd_vel_cb(const std_msgs::Float64MultiArray::ConstPtr& msg)
     {
         boost::mutex::scoped_lock lock(mutex_);
@@ -247,7 +223,6 @@ public:
 
         ros::Duration period_vel = event.current_real - last_vel_command_;
         ros::Duration period_pos = event.current_real - last_pos_command_;
-        ros::Duration period_interpol_pos = event.current_real - last_interpol_pos_command_;
 
         lock.unlock();
 
@@ -283,22 +258,6 @@ public:
                 }
             }
         }
-        else if(has_interpol_pos_controller_ && (period_interpol_pos.toSec() < max_command_silence_))
-        {
-            if(current_control_mode_!=INTERPOL_POSITION)
-            {
-                bool success = switchController(interpol_pos_controller_names_, current_controller_names_);
-                if(!success)
-                {
-                    ROS_ERROR("Unable to switch to interpolated position_controllers. Not executing command...");
-                }
-                else
-                {
-                    ROS_INFO("Successfully switched to interpolated position_controllers");
-                    current_control_mode_=INTERPOL_POSITION;
-                }
-            }
-        }
         else if(has_traj_controller_)
         {
             if(current_control_mode_!=TRAJECTORY)
@@ -306,10 +265,6 @@ public:
                 if(current_control_mode_==POSITION)
                 {
                     ROS_INFO("Have not heard a pos command for %f seconds, switched back to trajectory_controller", period_pos.toSec());
-                }
-                else if(current_control_mode_==INTERPOL_POSITION)
-                {
-                    ROS_INFO("Have not heard a interpolated pos command for %f seconds, switched back to trajectory_controller", period_interpol_pos.toSec());
                 }
                 else
                 {
@@ -343,22 +298,19 @@ private:
 
     enum
     {
-        NONE, VELOCITY, POSITION, INTERPOL_POSITION, TRAJECTORY
+        NONE, VELOCITY, POSITION, TRAJECTORY
     } current_control_mode_;
 
     std::vector< std::string > current_controller_names_;
     std::vector< std::string > traj_controller_names_;
     std::vector< std::string > pos_controller_names_;
-    std::vector< std::string > interpol_pos_controller_names_;
     std::vector< std::string > vel_controller_names_;
 
     bool has_traj_controller_;
     bool has_pos_controller_;
-    bool has_interpol_pos_controller_;
     bool has_vel_controller_;
 
     ros::Subscriber cmd_pos_sub_;
-    ros::Subscriber cmd_interpol_pos_sub_;
     ros::Subscriber cmd_vel_sub_;
 
     ros::ServiceClient load_client_;
@@ -366,7 +318,6 @@ private:
 
     double max_command_silence_;
     ros::Time last_pos_command_;
-    ros::Time last_interpol_pos_command_;
     ros::Time last_vel_command_;
     boost::mutex mutex_;
 };

--- a/cob_twist_controller/include/cob_twist_controller/controller_interfaces/controller_interface.h
+++ b/cob_twist_controller/include/cob_twist_controller/controller_interfaces/controller_interface.h
@@ -85,7 +85,7 @@ class ControllerInterfacePosition : public ControllerInterfacePositionBase
                                              const TwistControllerParams& params)
         : ControllerInterfacePositionBase(nh, params)
         {
-            pub_ = nh.advertise<std_msgs::Float64MultiArray>("joint_group_interpol_position_controller/command", 1);
+            pub_ = nh.advertise<std_msgs::Float64MultiArray>("joint_group_position_controller/command", 1);
         }
 
         ~ControllerInterfacePosition() {}

--- a/cob_twist_controller/include/cob_twist_controller/kinematic_extensions/kinematic_extension_urdf.h
+++ b/cob_twist_controller/include/cob_twist_controller/kinematic_extensions/kinematic_extension_urdf.h
@@ -96,7 +96,7 @@ class KinematicExtensionTorso : public KinematicExtensionURDF
             }
 
             joint_state_sub_ = nh_.subscribe("/torso/joint_states", 1, &KinematicExtensionURDF::jointstateCallback, dynamic_cast<KinematicExtensionURDF*>(this));
-            command_pub_ = nh_.advertise<std_msgs::Float64MultiArray>("/torso/joint_group_interpol_position_controller/command", 1);
+            command_pub_ = nh_.advertise<std_msgs::Float64MultiArray>("/torso/joint_group_velocity_controller/command", 1);
         }
 
         ~KinematicExtensionTorso() {}

--- a/cob_twist_controller/src/debug/test_forward_command_sine_node.cpp
+++ b/cob_twist_controller/src/debug/test_forward_command_sine_node.cpp
@@ -12,7 +12,7 @@ public:
         dof_ = 2;
         idx_ = 1;
 
-        output_pub_ = nh_.advertise<std_msgs::Float64MultiArray>("/torso/joint_group_interpol_position_controller/command", 1);
+        output_pub_ = nh_.advertise<std_msgs::Float64MultiArray>("/torso/joint_group_position_controller/command", 1);
 
         ros::Duration(1.0).sleep();
     }

--- a/cob_twist_controller/src/kinematic_extensions/kinematic_extension_urdf.cpp
+++ b/cob_twist_controller/src/kinematic_extensions/kinematic_extension_urdf.cpp
@@ -52,12 +52,12 @@ bool KinematicExtensionURDF::initExtension()
 
     for (unsigned int i = 0; i < chain_.getNrOfSegments(); i++)
     {
-        ROS_INFO_STREAM("Segment[" << i << "] Name : " << chain_.getSegment(i).getName());
-        ROS_INFO_STREAM("Joint[" << i << "] Name: " << chain_.getSegment(i).getJoint().getName());
-        ROS_INFO_STREAM("Joint[" << i << "] Type: " << chain_.getSegment(i).getJoint().getTypeName());
+        ROS_DEBUG_STREAM("Segment[" << i << "] Name : " << chain_.getSegment(i).getName());
+        ROS_DEBUG_STREAM("Joint[" << i << "] Name: " << chain_.getSegment(i).getJoint().getName());
+        ROS_DEBUG_STREAM("Joint[" << i << "] Type: " << chain_.getSegment(i).getJoint().getTypeName());
         if (chain_.getSegment(i).getJoint().getType() != KDL::Joint::None)
         {
-            ROS_INFO_STREAM("Adding Joint " << chain_.getSegment(i).getJoint().getName());
+            ROS_DEBUG_STREAM("Adding Joint " << chain_.getSegment(i).getJoint().getName());
             joint_names_.push_back(chain_.getSegment(i).getJoint().getName());
         }
     }


### PR DESCRIPTION
- cob4_torso extension should publish to `joint_group_velocity_controller`  
  :warning: Actually, before I was publishing velocities (`q_dot_ik`) directly to `joint_group_interpol_position_controller` instead of integrating them 
- removed all references to `joint_group_interpol_position_controller` as it did not prove helpful (see https://github.com/ipa320/cob_robots/pull/446)
- minor debug output
