### PR TITLE
cob omni wheel stuck detector

### DIFF
--- a/cob_omni_drive_controller/CMakeLists.txt
+++ b/cob_omni_drive_controller/CMakeLists.txt
@@ -31,8 +31,12 @@ add_library(cob_omni_drive_controller src/odom_plugin.cpp src/control_plugin.cpp
 add_dependencies(cob_omni_drive_controller ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(cob_omni_drive_controller cob_omni_drive_geom ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
+add_executable(cob_omni_drive_stuck_detector src/stuck_detector.cpp)
+add_dependencies(cob_omni_drive_stuck_detector ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(cob_omni_drive_stuck_detector ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
 ### INSTALL ###
-install(TARGETS cob_omni_drive_geom cob_omni_drive_controller
+install(TARGETS cob_omni_drive_geom cob_omni_drive_controller cob_omni_drive_stuck_detector
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
@@ -44,4 +48,8 @@ install(FILES controller_plugins.xml
 
 install(DIRECTORY include/${PROJECT_NAME}/
  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
+install(DIRECTORY launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/cob_omni_drive_controller/CMakeLists.txt
+++ b/cob_omni_drive_controller/CMakeLists.txt
@@ -1,12 +1,20 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cob_omni_drive_controller)
 
-find_package(catkin REQUIRED COMPONENTS angles controller_interface geometry_msgs hardware_interface nav_msgs sensor_msgs std_srvs tf urdf)
+find_package(catkin REQUIRED COMPONENTS angles controller_interface geometry_msgs hardware_interface message_generation nav_msgs realtime_tools sensor_msgs std_msgs std_srvs tf urdf)
 
 find_package(Boost REQUIRED COMPONENTS thread)
 
+add_message_files(
+  DIRECTORY msg
+  FILES
+  WheelCommands.msg
+)
+
+generate_messages(DEPENDENCIES std_msgs)
+
 catkin_package(
-  CATKIN_DEPENDS angles controller_interface geometry_msgs hardware_interface nav_msgs sensor_msgs std_srvs tf urdf
+  CATKIN_DEPENDS angles controller_interface geometry_msgs hardware_interface message_runtime nav_msgs sensor_msgs std_msgs std_srvs tf urdf
   DEPENDS Boost
   INCLUDE_DIRS include
   LIBRARIES cob_omni_drive_geom cob_omni_drive_controller
@@ -20,7 +28,7 @@ add_dependencies(cob_omni_drive_geom ${catkin_EXPORTED_TARGETS})
 target_link_libraries(cob_omni_drive_geom ${catkin_LIBRARIES})
 
 add_library(cob_omni_drive_controller src/odom_plugin.cpp src/control_plugin.cpp)
-add_dependencies(cob_omni_drive_controller ${catkin_EXPORTED_TARGETS})
+add_dependencies(cob_omni_drive_controller ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(cob_omni_drive_controller cob_omni_drive_geom ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 ### INSTALL ###

--- a/cob_omni_drive_controller/include/cob_omni_drive_controller/UndercarriageCtrlGeom.h
+++ b/cob_omni_drive_controller/include/cob_omni_drive_controller/UndercarriageCtrlGeom.h
@@ -80,6 +80,10 @@ public:
         double dAngGearSteerRad;
         WheelState() : dVelGearDriveRadS(0), dVelGearSteerRadS(0), dAngGearSteerRad(0) {}
     };
+    struct WheelCommand : public WheelState {
+        double dAngGearSteerRadDelta;
+        WheelCommand() : dAngGearSteerRadDelta(0) {}
+    };
     struct WheelGeom{
         std::string steer_name, drive_name;
 
@@ -234,7 +238,7 @@ public:
     void setTarget(const PlatformState &state);
 
     // Get set point values for the Wheels (including controller) from UndercarriangeCtrl
-    void calcControlStep(std::vector<WheelState> &states, double dCmdRateS, bool reset);
+    void calcControlStep(std::vector<WheelCommand> &commands, double dCmdRateS, bool reset);
 
     void reset();
 
@@ -255,7 +259,7 @@ private:
         // calculate inverse kinematics
         void setTarget(const PlatformState &state);
 
-        void calcControlStep(WheelState &command, double dCmdRateS, bool reset);
+        void calcControlStep(WheelCommand &command, double dCmdRateS, bool reset);
 
         void reset();
 

--- a/cob_omni_drive_controller/launch/stuck_detector.launch
+++ b/cob_omni_drive_controller/launch/stuck_detector.launch
@@ -1,0 +1,12 @@
+<launch>
+  <arg name="timeout" default="1.0" />
+  <arg name="threshold" default="1.57" />
+  <arg name="component_name" default="base" />
+  
+  <group ns="$(arg component_name)">
+    <node pkg="cob_omni_drive_controller" type="cob_omni_drive_stuck_detector" name="stuck_detector">
+        <param name="timeout" type="double" value="$(arg timeout)"/>
+        <param name="threshold" type="double" value="$(arg threshold)"/>
+    </node>
+  </group>
+</launch>

--- a/cob_omni_drive_controller/msg/WheelCommands.msg
+++ b/cob_omni_drive_controller/msg/WheelCommands.msg
@@ -1,0 +1,5 @@
+std_msgs/Header header
+float64[] drive_target_velocity
+float64[] steer_target_velocity
+float64[] steer_target_position
+float64[] steer_target_error

--- a/cob_omni_drive_controller/package.xml
+++ b/cob_omni_drive_controller/package.xml
@@ -22,6 +22,7 @@
   <depend>hardware_interface</depend>
   <depend>nav_msgs</depend>
   <depend>realtime_tools</depend>
+  <depend>roscpp</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>

--- a/cob_omni_drive_controller/package.xml
+++ b/cob_omni_drive_controller/package.xml
@@ -11,13 +11,19 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>message_generation</build_depend>
+  <build_export_depend>message_runtime</build_export_depend>
+  <exec_depend>message_runtime</exec_depend>
+  
   <depend>angles</depend>
   <depend>boost</depend>
   <depend>controller_interface</depend>
   <depend>geometry_msgs</depend>
   <depend>hardware_interface</depend>
   <depend>nav_msgs</depend>
+  <depend>realtime_tools</depend>
   <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>tf</depend>
   <depend>urdf</depend>

--- a/cob_omni_drive_controller/src/control_plugin.cpp
+++ b/cob_omni_drive_controller/src/control_plugin.cpp
@@ -91,7 +91,7 @@ private:
         ros::Time stamp;
     } target_;
 
-    std::vector<UndercarriageCtrl::WheelState> wheel_commands_;
+    std::vector<UndercarriageCtrl::WheelCommand> wheel_commands_;
 
     boost::mutex mutex_;
     ros::Subscriber twist_subscriber_;

--- a/cob_omni_drive_controller/src/control_plugin.cpp
+++ b/cob_omni_drive_controller/src/control_plugin.cpp
@@ -13,6 +13,9 @@
 
 #include "GeomController.h"
 
+#include <realtime_tools/realtime_publisher.h>
+#include <cob_omni_drive_controller/WheelCommands.h>
+
 namespace cob_omni_drive_controller
 {
 
@@ -42,15 +45,25 @@ public:
             return false;
         }
         timeout_.fromSec(timeout);
+        
+        pub_divider_ =  controller_nh.param("pub_divider",0);
 
         wheel_commands_.resize(wheel_states_.size());
         twist_subscriber_ = controller_nh.subscribe("command", 1, &WheelController::topicCallbackTwistCmd, this);
+
+        commands_pub_.reset(new realtime_tools::RealtimePublisher<cob_omni_drive_controller::WheelCommands>(controller_nh, "wheel_commands", 5));
+       
+        commands_pub_->msg_.drive_target_velocity.resize(wheel_states_.size());
+        commands_pub_->msg_.steer_target_velocity.resize(wheel_states_.size());
+        commands_pub_->msg_.steer_target_position.resize(wheel_states_.size());
+        commands_pub_->msg_.steer_target_error.resize(wheel_states_.size());
 
         return true;
   }
     virtual void starting(const ros::Time& time){
         geom_->reset();
         target_.updated = false;
+        cycles_ = 0;
     }
     virtual void update(const ros::Time& time, const ros::Duration& period){
 
@@ -81,6 +94,23 @@ public:
             steer_joints_[i].setCommand(wheel_commands_[i].dVelGearSteerRadS);
             drive_joints_[i].setCommand(wheel_commands_[i].dVelGearDriveRadS);
         }
+        
+        if(cycles_ < pub_divider_ && (++cycles_) == pub_divider_){
+            if(commands_pub_->trylock()){
+                ++(commands_pub_->msg_.header.seq);
+                commands_pub_->msg_.header.stamp = time;
+
+                for (unsigned i=0; i<wheel_commands_.size(); i++){
+                    commands_pub_->msg_.drive_target_velocity[i] = wheel_commands_[i].dVelGearDriveRadS;
+                    commands_pub_->msg_.steer_target_velocity[i] = wheel_commands_[i].dVelGearSteerRadS;
+                    commands_pub_->msg_.steer_target_position[i] = wheel_commands_[i].dAngGearSteerRad;
+                    commands_pub_->msg_.steer_target_error[i] = wheel_commands_[i].dAngGearSteerRadDelta;
+                }
+                commands_pub_->unlockAndPublish();
+            
+            }
+            cycles_ = 0;
+        }
     }
     virtual void stopping(const ros::Time& time) {}
 
@@ -95,7 +125,11 @@ private:
 
     boost::mutex mutex_;
     ros::Subscriber twist_subscriber_;
-
+    
+    boost::scoped_ptr<realtime_tools::RealtimePublisher<cob_omni_drive_controller::WheelCommands> > commands_pub_;
+    uint32_t cycles_;
+    uint32_t pub_divider_;
+    
     ros::Duration timeout_;
     double max_vel_trans_, max_vel_rot_;
 

--- a/cob_omni_drive_controller/src/stuck_detector.cpp
+++ b/cob_omni_drive_controller/src/stuck_detector.cpp
@@ -1,0 +1,59 @@
+#include <std_srvs/Trigger.h>
+#include <cob_omni_drive_controller/WheelCommands.h>
+#include <ros/ros.h>
+
+ros::ServiceClient g_halt_client;
+std::vector<ros::Time> g_last_ok;
+double g_threshold;
+ros::Duration g_timeout;
+bool g_halt_requested;
+
+void commandsCallback(const cob_omni_drive_controller::WheelCommands::ConstPtr& msg){
+    g_last_ok.resize(msg->steer_target_error.size(), msg->header.stamp);
+
+    bool valid = true;
+    for(size_t i = 0; i < msg->steer_target_error.size(); ++i){
+
+        if(fabs(msg->steer_target_error[i]) >= g_threshold){
+            valid = false;
+            if( (msg->header.stamp - g_last_ok[i]) >= g_timeout  && !g_halt_requested) {
+                g_halt_requested = true;
+                std_srvs::Trigger srv;
+                ROS_ERROR_STREAM("Wheel " << i << " exceeded threshold for too long, halting..");
+                g_halt_client.call(srv);
+            }
+        }else{
+            g_last_ok[i] = msg->header.stamp;
+        }
+    }
+
+    if(valid) g_halt_requested = false;
+}
+
+int main(int argc, char* argv[])
+{
+    ros::init(argc, argv, "cob_omni_drive_stuck_detector");
+    
+    ros::NodeHandle nh;
+    ros::NodeHandle nh_priv("~");
+    
+    double timeout;
+    if(!nh_priv.getParam("timeout", timeout) || timeout <= 0.0){
+        ROS_ERROR("Please provide valid timeout");
+        return 1;
+    }
+
+    if(!nh_priv.getParam("threshold", g_threshold)){
+        ROS_ERROR("Please provide stuck threshold");
+        return 1;
+    }
+
+    g_halt_requested = false;
+    g_timeout = ros::Duration(timeout);
+
+    ros::Subscriber status_sub = nh.subscribe("twist_controller/wheel_commands", 10, commandsCallback);
+    g_halt_client = nh.serviceClient<std_srvs::Trigger>("driver/halt");
+
+    ros::spin();
+    return 0;
+}

--- a/cob_undercarriage_ctrl_node/src/cob_undercarriage_ctrl_new.cpp
+++ b/cob_undercarriage_ctrl_node/src/cob_undercarriage_ctrl_new.cpp
@@ -520,8 +520,8 @@ int main(int argc, char** argv)
 void NodeClass::CalcCtrlStep()
 {
   // WheelStates will be initialized with zero-values
-  std::vector<UndercarriageCtrl::WheelState> wStates;
-  wStates.assign(m_iNumWheels, UndercarriageCtrl::WheelState());
+  std::vector<UndercarriageCtrl::WheelCommand> wStates;
+  wStates.assign(m_iNumWheels, UndercarriageCtrl::WheelCommand());
 
   // create control_msg
   control_msgs::JointTrajectoryControllerState joint_state_cmd;
@@ -655,13 +655,16 @@ void NodeClass::setEMStopActive(bool bEMStopActive)
     std::vector<UndercarriageCtrl::WheelState> wStates;
     wStates.assign(m_iNumWheels, UndercarriageCtrl::WheelState());
 
+    std::vector<UndercarriageCtrl::WheelCommand> wCommands;
+    wCommands.assign(m_iNumWheels, UndercarriageCtrl::WheelCommand());
+    
     // if emergency stop reset ctrlr to zero
     if(m_bEMStopActive)
     {
 //        std::cout << "EMStop: " << "Active" << std::endl;
         has_target = false;
         // reset and update current wheel states but keep current dAngGearSteerRad per wheelState
-        ucar_ctrl_->calcControlStep(wStates, sample_time_, true);
+        ucar_ctrl_->calcControlStep(wCommands, sample_time_, true);
 
         // set current wheel states with previous reset and updated wheelStates
         ucar_ctrl_->updateWheelStates(wStates);


### PR DESCRIPTION
As discussed with @ipa-tif this PR contains an extended cob_omni_drive_controller that publishes the steer target and error as `wheel_commands` topic if `pub_divider` param is not 0.

In addition the `cob_omni_drive_stuck_detector` node can be used to `driver/halt` the motor chain if the error exceeds the `threshold` parameter for longer than `timeout`seconds.

To be tested on hardware.
Defaults in launch file are rough estimates.
