### PR TITLE
[Do not merge] cleanup velocity smoother

### DIFF
--- a/cob_base_velocity_smoother/cfg/params.cfg
+++ b/cob_base_velocity_smoother/cfg/params.cfg
@@ -8,14 +8,14 @@ gen = ParameterGenerator()
 
 gen.add("speed_lim_vx", double_t, 0, "Maximum linear velocity", 1.0, 0.0, 10.0)
 gen.add("speed_lim_vy", double_t, 0, "Maximum linear velocity", 1.0, 0.0, 10.0)
-gen.add("speed_lim_w", double_t, 0, "Maximum angular velocity", 1.0, 0.0, 10.0)
+gen.add("speed_lim_w",  double_t, 0, "Maximum angular velocity", 1.0, 0.0, 10.0)
 
 gen.add("accel_lim_vx", double_t, 0, "Maximum linear acceleration", 0.7, 0.0, 10.0)
 gen.add("accel_lim_vy", double_t, 0, "Maximum linear acceleration", 0.7, 0.0, 10.0)
-gen.add("accel_lim_w", double_t, 0, "Maximum angular acceleration", 0.7, 0.0, 10.0)
+gen.add("accel_lim_w",  double_t, 0, "Maximum angular acceleration", 0.7, 0.0, 10.0)
 
 gen.add("decel_factor", double_t, 0, "Deceleration to acceleration ratio", 2.0, 0.0, 10.0)
-gen.add("decel_factor_safe", double_t, 0, "Deceleration to acceleration ratio if safety stop is required", 4.0, 0.0, 10.0)
+gen.add("safe_factor",  double_t, 0, "Multiplier in case safety stop is required", 4.0, 0.0, 10.0)
 
 # Second arg is node name it will run in (doc purposes only), third is generated filename prefix
 exit(gen.generate(PACKAGE, "velocity_smoother_configure", "params"))

--- a/cob_base_velocity_smoother/cfg/params.cfg
+++ b/cob_base_velocity_smoother/cfg/params.cfg
@@ -6,6 +6,12 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
+feedback_enum = gen.enum([gen.const("NONE",     int_t, 0, "No feedback"),
+                          gen.const("ODOMETRY", int_t, 1, "Odometry feedback"),
+                          gen.const("COMMANDS", int_t, 2, "Command feedback")],
+                          "enum types robot velocity feedback")
+gen.add("robot_feedback", int_t,  0, "What source to use as robot velocity feedback", 0, None, None, edit_method=feedback_enum)
+
 gen.add("speed_lim_vx", double_t, 0, "Maximum linear velocity", 1.0, 0.0, 10.0)
 gen.add("speed_lim_vy", double_t, 0, "Maximum linear velocity", 1.0, 0.0, 10.0)
 gen.add("speed_lim_w",  double_t, 0, "Maximum angular velocity", 1.0, 0.0, 10.0)

--- a/cob_base_velocity_smoother/cfg/params.cfg
+++ b/cob_base_velocity_smoother/cfg/params.cfg
@@ -12,13 +12,13 @@ feedback_enum = gen.enum([gen.const("NONE",     int_t, 0, "No feedback"),
                           "enum types robot velocity feedback")
 gen.add("robot_feedback", int_t,  0, "What source to use as robot velocity feedback", 0, None, None, edit_method=feedback_enum)
 
-gen.add("speed_lim_vx", double_t, 0, "Maximum linear velocity", 1.0, 0.0, 10.0)
-gen.add("speed_lim_vy", double_t, 0, "Maximum linear velocity", 1.0, 0.0, 10.0)
-gen.add("speed_lim_w",  double_t, 0, "Maximum angular velocity", 1.0, 0.0, 10.0)
+gen.add("speed_lim_vx", double_t, 0, "Maximum linear velocity [m/s]", 1.0, 0.0, 10.0)
+gen.add("speed_lim_vy", double_t, 0, "Maximum linear velocity [m/s]", 1.0, 0.0, 10.0)
+gen.add("speed_lim_w",  double_t, 0, "Maximum angular velocity [rad/s]", 1.0, 0.0, 10.0)
 
-gen.add("accel_lim_vx", double_t, 0, "Maximum linear acceleration", 0.7, 0.0, 10.0)
-gen.add("accel_lim_vy", double_t, 0, "Maximum linear acceleration", 0.7, 0.0, 10.0)
-gen.add("accel_lim_w",  double_t, 0, "Maximum angular acceleration", 0.7, 0.0, 10.0)
+gen.add("accel_lim_vx", double_t, 0, "Maximum linear acceleration [m/s2]", 0.7, 0.0, 10.0)
+gen.add("accel_lim_vy", double_t, 0, "Maximum linear acceleration [m/s2]", 0.7, 0.0, 10.0)
+gen.add("accel_lim_w",  double_t, 0, "Maximum angular acceleration [rad/s2]", 0.7, 0.0, 10.0)
 
 gen.add("decel_factor", double_t, 0, "Deceleration to acceleration ratio", 2.0, 0.0, 10.0)
 gen.add("safe_factor",  double_t, 0, "Multiplier in case safety stop is required", 4.0, 0.0, 10.0)

--- a/cob_base_velocity_smoother/include/cob_base_velocity_smoother/velocity_smoother.h
+++ b/cob_base_velocity_smoother/include/cob_base_velocity_smoother/velocity_smoother.h
@@ -50,9 +50,9 @@ public:
 private:
   enum RobotFeedbackType
   {
-    NONE,
-    ODOMETRY,
-    COMMANDS
+    NONE     = cob_base_velocity_smoother::params_NONE,
+    ODOMETRY = cob_base_velocity_smoother::params_ODOMETRY,
+    COMMANDS = cob_base_velocity_smoother::params_COMMANDS
   } robot_feedback;  /**< What source to use as robot velocity feedback */
 
   std::string name;

--- a/cob_base_velocity_smoother/include/cob_base_velocity_smoother/velocity_smoother.h
+++ b/cob_base_velocity_smoother/include/cob_base_velocity_smoother/velocity_smoother.h
@@ -1,6 +1,4 @@
 /**
- * @file /include/yocs_velocity_smoother/velocity_smoother_nodelet.hpp
- *
  * @brief Velocity smoother interface
  *
  * License: BSD
@@ -23,6 +21,7 @@
 #include <dynamic_reconfigure/server.h>
 #include <cob_base_velocity_smoother/paramsConfig.h>
 #include <nav_msgs/Odometry.h>
+#include <boost/thread/mutex.hpp>
 
 /*****************************************************************************
 ** Namespaces
@@ -46,8 +45,7 @@ public:
   }
 
   bool init(ros::NodeHandle& nh);
-  void spin();
-  void shutdown() { shutdown_req = true; };
+  void spin(const ros::TimerEvent& event);
 
 private:
   enum RobotFeedbackType
@@ -58,23 +56,24 @@ private:
   } robot_feedback;  /**< What source to use as robot velocity feedback */
 
   std::string name;
-  double speed_lim_vx, accel_lim_vx, decel_lim_vx, decel_lim_vx_safe;
-  double speed_lim_vy, accel_lim_vy, decel_lim_vy, decel_lim_vy_safe;
-  double speed_lim_w, accel_lim_w, decel_lim_w, decel_lim_w_safe;
-  double decel_factor, decel_factor_safe;
+  double speed_lim_vx, accel_lim_vx;
+  double speed_lim_vy, accel_lim_vy;
+  double speed_lim_w, accel_lim_w;
+  double decel_factor, safe_factor;
 
   double frequency;
+  ros::Timer timer;
+  boost::mutex _mutex;
 
   geometry_msgs::Twist last_cmd_vel;
-  geometry_msgs::Twist  current_vel;
-  geometry_msgs::Twist   target_vel;
+  geometry_msgs::Twist current_vel;
+  geometry_msgs::Twist target_vel;
 
-  bool                 shutdown_req; /**< Shutdown requested by nodelet; kill worker thread */
   bool                 input_active;
-  double                cb_avg_time;
+  double               cb_avg_time;
   ros::Time            last_cb_time;
-  std::vector<double> period_record; /**< Historic of latest periods between velocity commands */
-  unsigned int             pr_next; /**< Next position to fill in the periods record buffer */
+  std::vector<double>  period_record; /**< Historic of latest periods between velocity commands */
+  unsigned int         pr_next;       /**< Next position to fill in the periods record buffer */
 
   ros::Subscriber odometry_sub;    /**< Current velocity from odometry */
   ros::Subscriber current_vel_sub; /**< Current velocity from commands sent to the robot, not necessarily by this node */
@@ -88,8 +87,7 @@ private:
   double sign(double x)  { return x < 0.0 ? -1.0 : +1.0; };
 
   double median(std::vector<double> values) {
-    // Return the median element of an doubles vector
-    nth_element(values.begin(), values.begin() + values.size()/2, values.end());
+    // Return the median element of a vector of doubles
     return values[values.size()/2];
   };
 

--- a/cob_base_velocity_smoother/src/cob_base_velocity_smoother/velocity_smoother.cpp
+++ b/cob_base_velocity_smoother/src/cob_base_velocity_smoother/velocity_smoother.cpp
@@ -45,9 +45,10 @@ VelocitySmoother::VelocitySmoother(const std::string &name)
 
 void VelocitySmoother::reconfigCB(cob_base_velocity_smoother::paramsConfig &config, uint32_t level)
 {
-  ROS_INFO("Reconfigure request : \n\tSpeedLimit: %f %f %f \n\tAccLimit: %f %f %f\n\tDecelFactor: %f, SafeFactor: %f",
-           config.speed_lim_vx, config.speed_lim_vy, config.speed_lim_w, config.accel_lim_vx, config.accel_lim_vy, config.accel_lim_w, config.decel_factor, config.safe_factor);
+  ROS_INFO("Reconfigure request : \n\tSpeedLimit: %f %f %f \n\tAccLimit: %f %f %f\n\tDecelFactor: %f, SafeFactor: %f \n\tRobotFeedback: %d",
+           config.speed_lim_vx, config.speed_lim_vy, config.speed_lim_w, config.accel_lim_vx, config.accel_lim_vy, config.accel_lim_w, config.decel_factor, config.safe_factor, config.robot_feedback);
 
+  robot_feedback = (VelocitySmoother::RobotFeedbackType) config.robot_feedback;
   speed_lim_vx  = config.speed_lim_vx;
   speed_lim_vy  = config.speed_lim_vy;
   speed_lim_w   = config.speed_lim_w;

--- a/cob_base_velocity_smoother/src/cob_base_velocity_smoother/velocity_smoother.cpp
+++ b/cob_base_velocity_smoother/src/cob_base_velocity_smoother/velocity_smoother.cpp
@@ -183,21 +183,37 @@ void VelocitySmoother::spin(const ros::TimerEvent& event)
     vx_inc = target_vel.linear.x - last_cmd_vel.linear.x;
     ax = vx_inc/cb_avg_time;
     max_ax = (ax > 0.0)?accel_vx:decel_vx;
-    actual_ax = (std::abs(ax) > max_ax)?sign(ax)*max_ax:ax;
+    //actual_ax = (std::abs(ax) > max_ax)?sign(ax)*max_ax:ax;
 
     vy_inc = target_vel.linear.y - last_cmd_vel.linear.y;
     ay = vy_inc/cb_avg_time;
     max_ay = (ay > 0.0)?accel_vy:decel_vy;
-    actual_ay = (std::abs(ay) > max_ay)?sign(ay)*max_ay:ay;
+    //actual_ay = (std::abs(ay) > max_ay)?sign(ay)*max_ay:ay;
 
     w_inc = target_vel.angular.z - last_cmd_vel.angular.z;
     aw = w_inc/cb_avg_time;
     max_aw = (aw > 0.0)?accel_w:decel_w;
-    actual_aw = (std::abs(aw) > max_aw)?sign(aw)*max_aw:aw;
+    //actual_aw = (std::abs(aw) > max_aw)?sign(aw)*max_aw:aw;
+    
+    // limit acceleration
+    //cmd_vel.linear.x  = last_cmd_vel.linear.x  + actual_ax*period;
+    //cmd_vel.linear.y  = last_cmd_vel.linear.y  + actual_ay*period;
+    //cmd_vel.angular.z = last_cmd_vel.angular.z + actual_aw*period;
 
-    cmd_vel.linear.x  = last_cmd_vel.linear.x  + actual_ax*period;
-    cmd_vel.linear.y  = last_cmd_vel.linear.y  + actual_ay*period;
-    cmd_vel.angular.z = last_cmd_vel.angular.z + actual_aw*period;
+
+    // go as fast as possible without over-shoot
+    if (std::abs(sign(ax)*max_ax*period)<std::abs(vx_inc))
+    {
+      cmd_vel.linear.x  = last_cmd_vel.linear.x  + sign(ax)*max_ax*period;
+    }
+    if (std::abs(sign(ay)*max_ay*period)<std::abs(vy_inc))
+    {
+      cmd_vel.linear.y  = last_cmd_vel.linear.y  + sign(ay)*max_ay*period;
+    }
+    if (std::abs(sign(aw)*max_aw*period)<std::abs(w_inc))
+    {
+      cmd_vel.angular.z  = last_cmd_vel.angular.z  + sign(aw)*max_aw*period;
+    }
 
     smooth_vel_pub.publish(cmd_vel);
     last_cmd_vel = cmd_vel;

--- a/cob_base_velocity_smoother/src/cob_base_velocity_smoother/velocity_smoother.cpp
+++ b/cob_base_velocity_smoother/src/cob_base_velocity_smoother/velocity_smoother.cpp
@@ -37,7 +37,6 @@ namespace cob_base_velocity_smoother {
 
 VelocitySmoother::VelocitySmoother(const std::string &name)
 : name(name)
-, shutdown_req(false)
 , input_active(false)
 , pr_next(0)
 , dynamic_reconfigure_server(NULL)
@@ -46,46 +45,43 @@ VelocitySmoother::VelocitySmoother(const std::string &name)
 
 void VelocitySmoother::reconfigCB(cob_base_velocity_smoother::paramsConfig &config, uint32_t level)
 {
-  ROS_INFO("Reconfigure request : %f %f %f %f %f %f %f %f",
-           config.speed_lim_vx, config.speed_lim_vy, config.speed_lim_w, config.accel_lim_vx, config.accel_lim_vy, config.accel_lim_w, config.decel_factor, config.decel_factor_safe);
+  ROS_INFO("Reconfigure request : \n\tSpeedLimit: %f %f %f \n\tAccLimit: %f %f %f\n\tDecelFactor: %f, SafeFactor: %f",
+           config.speed_lim_vx, config.speed_lim_vy, config.speed_lim_w, config.accel_lim_vx, config.accel_lim_vy, config.accel_lim_w, config.decel_factor, config.safe_factor);
 
   speed_lim_vx  = config.speed_lim_vx;
   speed_lim_vy  = config.speed_lim_vy;
-  speed_lim_w  = config.speed_lim_w;
+  speed_lim_w   = config.speed_lim_w;
   accel_lim_vx  = config.accel_lim_vx;
   accel_lim_vy  = config.accel_lim_vy;
-  accel_lim_w  = config.accel_lim_w;
-  decel_factor = config.decel_factor;
-  decel_factor_safe = config.decel_factor_safe;
-  decel_lim_vx  = decel_factor*accel_lim_vx;
-  decel_lim_vy  = decel_factor*accel_lim_vy;
-  decel_lim_w  = decel_factor*accel_lim_w;
-  decel_lim_vx_safe = decel_factor_safe*accel_lim_vx;
-  decel_lim_vy_safe = decel_factor_safe*accel_lim_vy;
-  decel_lim_w_safe = decel_factor_safe*accel_lim_w;
+  accel_lim_w   = config.accel_lim_w;
+  decel_factor  = config.decel_factor;
+  safe_factor   = config.safe_factor;
 }
 
 void VelocitySmoother::velocityCB(const geometry_msgs::Twist::ConstPtr& msg)
 {
-  // Estimate commands frequency; we do continuously as it can be very different depending on the
-  // publisher type, and we don't want to impose extra constraints to keep this package flexible
+  boost::mutex::scoped_lock lock(_mutex);
+
+  ros::Time now = ros::Time::now();
+  double duration = (now - last_cb_time).toSec();
+  
   if (period_record.size() < PERIOD_RECORD_SIZE)
   {
-    period_record.push_back((ros::Time::now() - last_cb_time).toSec());
+    period_record.push_back(duration);
   }
   else
   {
-    period_record[pr_next] = (ros::Time::now() - last_cb_time).toSec();
+    period_record[pr_next] = duration;
   }
 
   pr_next++;
   pr_next %= period_record.size();
-  last_cb_time = ros::Time::now();
+  last_cb_time = now;
 
   if (period_record.size() <= PERIOD_RECORD_SIZE/2)
   {
-    // wait until we have some values; make a reasonable assumption (10 Hz) meanwhile
-    cb_avg_time = 0.1;
+    // wait until we have some values; make a reasonable assumption meanwhile
+    cb_avg_time = 1.0/frequency;
   }
   else
   {
@@ -93,19 +89,21 @@ void VelocitySmoother::velocityCB(const geometry_msgs::Twist::ConstPtr& msg)
     cb_avg_time = median(period_record);
   }
 
-  input_active = true;
-
   // Bound speed with the maximum values
   target_vel.linear.x  =
       msg->linear.x  > 0.0 ? std::min(msg->linear.x,  speed_lim_vx) : std::max(msg->linear.x,  -speed_lim_vx);
   target_vel.linear.y  =
       msg->linear.y  > 0.0 ? std::min(msg->linear.y,  speed_lim_vy) : std::max(msg->linear.y,  -speed_lim_vy);
   target_vel.angular.z =
-      msg->angular.z > 0.0 ? std::min(msg->angular.z, speed_lim_w) : std::max(msg->angular.z, -speed_lim_w);
+      msg->angular.z > 0.0 ? std::min(msg->angular.z, speed_lim_w)  : std::max(msg->angular.z, -speed_lim_w);
+
+  input_active = true;
 }
 
 void VelocitySmoother::odometryCB(const nav_msgs::Odometry::ConstPtr& msg)
 {
+  boost::mutex::scoped_lock lock(_mutex);
+
   if (robot_feedback == ODOMETRY)
     current_vel = msg->twist.twist;
 
@@ -114,179 +112,108 @@ void VelocitySmoother::odometryCB(const nav_msgs::Odometry::ConstPtr& msg)
 
 void VelocitySmoother::robotVelCB(const geometry_msgs::Twist::ConstPtr& msg)
 {
+  boost::mutex::scoped_lock lock(_mutex);
+
   if (robot_feedback == COMMANDS)
     current_vel = *msg;
 
   // ignore otherwise
 }
 
-void VelocitySmoother::spin()
+void VelocitySmoother::spin(const ros::TimerEvent& event)
 {
+  boost::mutex::scoped_lock lock(_mutex);
+
   double period = 1.0/frequency;
-  ros::Rate spin_rate(frequency);
+  double last_command = (event.current_real - last_cb_time).toSec();
 
-  double decel_vx;
-  double decel_vy;
-  double decel_w;
-
-  while (! shutdown_req && ros::ok())
+  if ((input_active == true) && (cb_avg_time > 0.0) &&
+      (last_command > std::min(PERIOD_RECORD_SIZE*cb_avg_time, 0.5))) //missed PERIOD_RECORD_SIZE input cycles or no input for 0.5 secs
   {
-    if ((input_active == true) && (cb_avg_time > 0.0) &&
-        ((ros::Time::now() - last_cb_time).toSec() > std::min(3.0*cb_avg_time, 0.5)))
+    // Velocity input not active anymore; normally last command is a zero-velocity one, but reassure
+    // this, just in case something went wrong with our input, or he just forgot good manners...
+    input_active = false;
+    ROS_WARN_STREAM("Velocity Smoother : input got inactive");
+    if (IS_ZERO_VEOCITY(target_vel) == false)
     {
-      // Velocity input no active anymore; normally last command is a zero-velocity one, but reassure
-      // this, just in case something went wrong with our input, or he just forgot good manners...
-      // Issue #2, extra check in case cb_avg_time is very big, for example with several atomic commands
-      // The cb_avg_time > 0 check is required to deal with low-rate simulated time, that can make that
-      // several messages arrive with the same time and so lead to a zero median
-      input_active = false;
-      if (IS_ZERO_VEOCITY(target_vel) == false)
-      {
-        ROS_WARN_STREAM("Velocity Smoother : input got inactive leaving us a non-zero target velocity ("
-              << target_vel.linear.x << ", " << target_vel.linear.y << ", " << target_vel.angular.z << "), zeroing...[" << name << "]");
-        target_vel = ZERO_VEL_COMMAND;
-      }
+      ROS_WARN_STREAM("...leaving us a non-zero target velocity ("
+            << target_vel.linear.x << ", " << target_vel.linear.y << ", " << target_vel.angular.z << "), zeroing...[" << name << "]");
+      target_vel = ZERO_VEL_COMMAND;
+    }
+  }
+
+  double accel_vx = (input_active)?accel_lim_vx:safe_factor*accel_lim_vx;
+  double accel_vy = (input_active)?accel_lim_vy:safe_factor*accel_lim_vy;
+  double accel_w  = (input_active)?accel_lim_w :safe_factor*accel_lim_w;
+
+  double decel_vx = decel_factor*accel_vx;
+  double decel_vy = decel_factor*accel_vy;
+  double decel_w  = decel_factor*accel_w;
+
+  if ((robot_feedback != NONE) && (input_active == true) && (cb_avg_time > 0.0) &&
+      ((last_command > std::min(PERIOD_RECORD_SIZE*cb_avg_time, 0.5))    || //missed PERIOD_RECORD_SIZE input cycles or no input for 0.5 secs
+       (std::abs(current_vel.linear.x  - last_cmd_vel.linear.x)  > 0.2)  ||
+       (std::abs(current_vel.linear.y  - last_cmd_vel.linear.y)  > 0.2)  ||
+       (std::abs(current_vel.angular.z - last_cmd_vel.angular.z) > 2.0)))
+  {
+    // If the publisher has been inactive for a while, or if our current commanding differs a lot
+    // from robot velocity feedback, we cannot trust the former; rely on robot's feedback instead
+    // This can happen mainly due to preemption of current controller on velocity multiplexer.
+    // TODO: current command/feedback difference thresholds are arbitrary; they should somehow
+    // be proportional to max v and w...
+    ROS_WARN("Last command differs to much from robot velocity feedback (%s). Use feedback instead!",
+              robot_feedback == ODOMETRY ? "ODOMETRY" : "COMMAND");
+    last_cmd_vel = current_vel;
+  }
+
+  if ((target_vel.linear.x  != last_cmd_vel.linear.x) ||
+      (target_vel.linear.y  != last_cmd_vel.linear.y) ||
+      (target_vel.angular.z != last_cmd_vel.angular.z))
+  {
+    // Try to reach target velocity ensuring that we don't exceed the acceleration limits
+    geometry_msgs::Twist cmd_vel = target_vel;
+
+    double vx_inc, vy_inc, w_inc, max_vx_inc, max_vy_inc, max_w_inc;
+
+    vx_inc = target_vel.linear.x - last_cmd_vel.linear.x;
+    max_vx_inc = ((vx_inc > 0.0)?accel_vx:decel_vx)*period;
+
+    vy_inc = target_vel.linear.y - last_cmd_vel.linear.y;
+    max_vy_inc = ((vy_inc > 0.0)?accel_vy:decel_vy)*period;
+
+    w_inc = target_vel.angular.z - last_cmd_vel.angular.z;
+    max_w_inc = ((w_inc > 0.0)?accel_w:decel_w)*period;
+
+    if (std::abs(vx_inc) > max_vx_inc)
+    {
+      // we must limit linear velocity
+      cmd_vel.linear.x  = last_cmd_vel.linear.x  + sign(vx_inc)*max_vx_inc;
     }
 
-    if(input_active)
+    if (std::abs(vy_inc) > max_vy_inc)
     {
-      decel_vx = decel_lim_vx;
-      decel_vy = decel_lim_vy;
-      decel_w = decel_lim_w;
-    }
-    else
-    {
-      //increase decel factor because this is a safty case, no more commands means we should stop as fast as it is safe
-      decel_vx = decel_lim_vx_safe;
-      decel_vy = decel_lim_vy_safe;
-      decel_w = decel_lim_w_safe;
+      // we must limit linear velocity
+      cmd_vel.linear.y  = last_cmd_vel.linear.y  + sign(vy_inc)*max_vy_inc;
     }
 
-    if ((robot_feedback != NONE) && (input_active == true) && (cb_avg_time > 0.0) &&
-        (((ros::Time::now() - last_cb_time).toSec() > 5.0*cb_avg_time)     || // 5 missing msgs
-          (std::abs(current_vel.linear.x  - last_cmd_vel.linear.x)  > 0.2) ||
-          (std::abs(current_vel.linear.y  - last_cmd_vel.linear.y)  > 0.2) ||
-          (std::abs(current_vel.angular.z - last_cmd_vel.angular.z) > 2.0)))
+    if (std::abs(w_inc) > max_w_inc)
     {
-      // If the publisher has been inactive for a while, or if our current commanding differs a lot
-      // from robot velocity feedback, we cannot trust the former; relay on robot's feedback instead
-      // This can happen mainly due to preemption of current controller on velocity multiplexer.
-      // TODO: current command/feedback difference thresholds are 진짜 arbitrary; they should somehow
-      // be proportional to max v and w...
-      // The one for angular velocity is very big because is it's less necessary (for example the
-      // reactive controller will never make the robot spin) and because the gyro has a 15 ms delay
-      ROS_WARN("Using robot velocity feedback (%s) instead of last command: %f, %f, %f, %f",
-                robot_feedback == ODOMETRY ? "odometry" : "end commands",
-               (ros::Time::now()      - last_cb_time).toSec(),
-                current_vel.linear.x  - last_cmd_vel.linear.x,
-                current_vel.linear.y  - last_cmd_vel.linear.y,
-                current_vel.angular.z - last_cmd_vel.angular.z);
-      last_cmd_vel = current_vel;
+      // we must limit angular velocity
+      cmd_vel.angular.z = last_cmd_vel.angular.z + sign(w_inc)*max_w_inc;
     }
 
-    geometry_msgs::TwistPtr cmd_vel;
-
-    if ((target_vel.linear.x  != last_cmd_vel.linear.x) ||
-        (target_vel.linear.y  != last_cmd_vel.linear.y) ||
-        (target_vel.angular.z != last_cmd_vel.angular.z))
-    {
-      // Try to reach target velocity ensuring that we don't exceed the acceleration limits
-      cmd_vel.reset(new geometry_msgs::Twist(target_vel));
-
-      double vx_inc, vy_inc, w_inc, max_vx_inc, max_vy_inc, max_w_inc;
-
-      vx_inc = target_vel.linear.x - last_cmd_vel.linear.x;
-      if ((robot_feedback == ODOMETRY) && (current_vel.linear.x*target_vel.linear.x < 0.0))
-      {
-        // countermarch (on robots with significant inertia; requires odometry feedback to be detected)
-        max_vx_inc = decel_vx*period;
-      }
-      else
-      {
-        max_vx_inc = ((vx_inc*target_vel.linear.x > 0.0)?accel_lim_vx:decel_vx)*period;
-      }
-
-      vy_inc = target_vel.linear.y - last_cmd_vel.linear.y;
-      if ((robot_feedback == ODOMETRY) && (current_vel.linear.y*target_vel.linear.y < 0.0))
-      {
-        // countermarch (on robots with significant inertia; requires odometry feedback to be detected)
-        max_vy_inc = decel_vy*period;
-      }
-      else
-      {
-        max_vy_inc = ((vy_inc*target_vel.linear.x > 0.0)?accel_lim_vy:decel_vy)*period;
-      }
-
-      w_inc = target_vel.angular.z - last_cmd_vel.angular.z;
-      if ((robot_feedback == ODOMETRY) && (current_vel.angular.z*target_vel.angular.z < 0.0))
-      {
-        // countermarch (on robots with significant inertia; requires odometry feedback to be detected)
-        max_w_inc = decel_w*period;
-      }
-      else
-      {
-        max_w_inc = ((w_inc*target_vel.angular.z > 0.0)?accel_lim_w:decel_w)*period;
-      }
-
-/*
-      // Calculate and normalise vectors A (desired velocity increment) and B (maximum velocity increment),
-      // where v acts as coordinate x and w as coordinate y; the sign of the angle from A to B determines
-      // which velocity (v or w) must be overconstrained to keep the direction provided as command
-      double MA = sqrt(    vx_inc *     vx_inc +     w_inc *     w_inc);
-      double MB = sqrt(max_vx_inc * max_vx_inc + max_w_inc * max_w_inc);
-
-      double Av = std::abs(vx_inc) / MA;
-      double Aw = std::abs(w_inc) / MA;
-      double Bv = max_vx_inc / MB;
-      double Bw = max_w_inc / MB;
-      double theta = atan2(Bw, Bv) - atan2(Aw, Av);
-
-      if (theta < 0)
-      {
-        // overconstrain linear velocity
-        max_vx_inc = (max_w_inc*std::abs(vx_inc))/std::abs(w_inc);
-      }
-      else
-      {
-        // overconstrain angular velocity
-        max_w_inc = (max_vx_inc*std::abs(w_inc))/std::abs(vx_inc);
-      }
-*/
-      if (std::abs(vx_inc) > max_vx_inc)
-      {
-        // we must limit linear velocity
-        cmd_vel->linear.x  = last_cmd_vel.linear.x  + sign(vx_inc)*max_vx_inc;
-      }
-
-      if (std::abs(vy_inc) > max_vy_inc)
-      {
-        // we must limit linear velocity
-        cmd_vel->linear.y  = last_cmd_vel.linear.y  + sign(vy_inc)*max_vy_inc;
-      }
-
-      if (std::abs(w_inc) > max_w_inc)
-      {
-        // we must limit angular velocity
-        cmd_vel->angular.z = last_cmd_vel.angular.z + sign(w_inc)*max_w_inc;
-      }
-
-      smooth_vel_pub.publish(cmd_vel);
-      last_cmd_vel = *cmd_vel;
-    }
-    else if (input_active == true)
-    {
-      // We already reached target velocity; just keep resending last command while input is active
-      cmd_vel.reset(new geometry_msgs::Twist(last_cmd_vel));
-      smooth_vel_pub.publish(cmd_vel);
-    }
-
-    spin_rate.sleep();
+    smooth_vel_pub.publish(cmd_vel);
+    last_cmd_vel = cmd_vel;
+  }
+  else if (input_active == true)
+  {
+    smooth_vel_pub.publish(target_vel);
   }
 }
 
 /**
- * Initialise from a nodelet's private nodehandle.
- * @param nh : private nodehandle
+ * Initialise from private NodeHandle.
+ * @param nh : private NodeHandle
  * @return bool : success or failure
  */
 bool VelocitySmoother::init(ros::NodeHandle& nh)
@@ -297,53 +224,15 @@ bool VelocitySmoother::init(ros::NodeHandle& nh)
   dynamic_reconfigure_server = new dynamic_reconfigure::Server<cob_base_velocity_smoother::paramsConfig>(nh);
   dynamic_reconfigure_server->setCallback(dynamic_reconfigure_callback);
 
-  // Optional parameters
-  int feedback;
-  nh.param("frequency",      frequency,     20.0);
-  nh.param("decel_factor",   decel_factor,   1.0);
-  nh.param("decel_factor_safty",   decel_factor_safe,   1.0);
-  nh.param("robot_feedback", feedback, (int)NONE);
-
-  if ((int(feedback) < NONE) || (int(feedback) > COMMANDS))
-  {
-    ROS_WARN("Invalid robot feedback type (%d). Valid options are 0 (NONE, default), 1 (ODOMETRY) and 2 (COMMANDS)",
-             feedback);
-    feedback = NONE;
-  }
-
-  robot_feedback = static_cast<RobotFeedbackType>(feedback);
-
-  // Mandatory parameters
-  if ((nh.getParam("speed_lim_vx", speed_lim_vx) == false) ||
-      (nh.getParam("speed_lim_vy", speed_lim_vy) == false) ||
-      (nh.getParam("speed_lim_w", speed_lim_w) == false))
-  {
-    ROS_ERROR("Missing velocity limit parameter(s)");
-    return false;
-  }
-
-  if ((nh.getParam("accel_lim_vx", accel_lim_vx) == false) ||
-      (nh.getParam("accel_lim_vy", accel_lim_vy) == false) ||
-      (nh.getParam("accel_lim_w", accel_lim_w) == false))
-  {
-    ROS_ERROR("Missing acceleration limit parameter(s)");
-    return false;
-  }
-
-  // Deceleration can be more aggressive, if necessary
-  decel_lim_vx = decel_factor*accel_lim_vx;
-  decel_lim_vy = decel_factor*accel_lim_vy;
-  decel_lim_w = decel_factor*accel_lim_w;
-  // In safety cases (no topic command anymore), deceleration should be very aggressive
-  decel_lim_vx_safe = decel_factor_safe*accel_lim_vx;
-  decel_lim_vy_safe = decel_factor_safe*accel_lim_vy;
-  decel_lim_w_safe = decel_factor_safe*accel_lim_w;
+  nh.param("frequency",      frequency,     50.0);
 
   // Publishers and subscribers
   odometry_sub    = nh.subscribe("odometry",      1, &VelocitySmoother::odometryCB, this);
   current_vel_sub = nh.subscribe("robot_cmd_vel", 1, &VelocitySmoother::robotVelCB, this);
   raw_in_vel_sub  = nh.subscribe("raw_cmd_vel",   1, &VelocitySmoother::velocityCB, this);
   smooth_vel_pub  = nh.advertise <geometry_msgs::Twist> ("smooth_cmd_vel", 1);
+
+  timer = nh.createTimer(ros::Duration(1.0/frequency), &VelocitySmoother::spin, this);
 
   return true;
 }

--- a/cob_base_velocity_smoother/src/cob_base_velocity_smoother/velocity_smoother.cpp
+++ b/cob_base_velocity_smoother/src/cob_base_velocity_smoother/velocity_smoother.cpp
@@ -174,33 +174,38 @@ void VelocitySmoother::spin(const ros::TimerEvent& event)
     // Try to reach target velocity ensuring that we don't exceed the acceleration limits
     geometry_msgs::Twist cmd_vel = target_vel;
 
-    double vx_inc, vy_inc, w_inc, max_vx_inc, max_vy_inc, max_w_inc;
+    double vx_inc, vy_inc, w_inc;
+    double ax, ay, aw;
+    double max_ax, max_ay, max_aw;
 
     vx_inc = target_vel.linear.x - last_cmd_vel.linear.x;
-    max_vx_inc = ((vx_inc > 0.0)?accel_vx:decel_vx)*period;
+    ax = vx_inc/cb_avg_time;
+    max_ax = (ax > 0.0)?accel_vx:decel_vx;
 
     vy_inc = target_vel.linear.y - last_cmd_vel.linear.y;
-    max_vy_inc = ((vy_inc > 0.0)?accel_vy:decel_vy)*period;
+    ay = vy_inc/cb_avg_time;
+    max_ay = (ay > 0.0)?accel_vy:decel_vy;
 
     w_inc = target_vel.angular.z - last_cmd_vel.angular.z;
-    max_w_inc = ((w_inc > 0.0)?accel_w:decel_w)*period;
+    aw = w_inc/cb_avg_time;
+    max_aw = (aw > 0.0)?accel_w:decel_w;
 
-    if (std::abs(vx_inc) > max_vx_inc)
+    if (std::abs(ax) > max_ax)
     {
       // we must limit linear velocity
-      cmd_vel.linear.x  = last_cmd_vel.linear.x  + sign(vx_inc)*max_vx_inc;
+      cmd_vel.linear.x  = last_cmd_vel.linear.x  + sign(ax)*max_ax*period;
     }
 
-    if (std::abs(vy_inc) > max_vy_inc)
+    if (std::abs(ay) > max_ay)
     {
       // we must limit linear velocity
-      cmd_vel.linear.y  = last_cmd_vel.linear.y  + sign(vy_inc)*max_vy_inc;
+      cmd_vel.linear.y  = last_cmd_vel.linear.y  + sign(ay)*max_ay*period;
     }
 
-    if (std::abs(w_inc) > max_w_inc)
+    if (std::abs(aw) > max_aw)
     {
       // we must limit angular velocity
-      cmd_vel.angular.z = last_cmd_vel.angular.z + sign(w_inc)*max_w_inc;
+      cmd_vel.angular.z = last_cmd_vel.angular.z + sign(aw)*max_aw*period;
     }
 
     smooth_vel_pub.publish(cmd_vel);

--- a/cob_base_velocity_smoother/src/velocity_smoother_node.cpp
+++ b/cob_base_velocity_smoother/src/velocity_smoother_node.cpp
@@ -1,5 +1,4 @@
 #include <ros/ros.h>
-#include <boost/thread.hpp>
 
 #include <cob_base_velocity_smoother/velocity_smoother.h>
 
@@ -18,28 +17,16 @@ int main(int argc, char** argv)
   std::string name = unresolvedName(resolved_name); // unresolve it ourselves
 
   boost::shared_ptr<VelocitySmoother> vel_smoother_;
-  boost::shared_ptr<boost::thread>   worker_thread_;
 
   vel_smoother_.reset(new VelocitySmoother(name));
-  if (vel_smoother_->init(nh_p))
-  {
-    ROS_DEBUG_STREAM("Velocity Smoother: initialised [" << name << "]");
-    worker_thread_.reset(new boost::thread(&VelocitySmoother::spin, vel_smoother_));
-  }
-  else
+  if (!vel_smoother_->init(nh_p))
   {
     ROS_ERROR_STREAM("Velocity Smoother: initialisation failed [" << name << "]");
+    return -1;
   }
 
-  ros::Rate r(100);
-  while (ros::ok())
-  {
-    ros::spinOnce();
-    r.sleep();
-  }
+  ROS_DEBUG_STREAM("Velocity Smoother: initialised [" << name << "]");
+  ros::spin();
 
-  vel_smoother_->shutdown();
-  worker_thread_->join();
-  
   return 0;
 }


### PR DESCRIPTION
@ipa-bnm 

While trying to understand the velocity smoother (limiter :wink:), I did some cleanup, i.e.
 - threading
 - parameter/dynamic-reconfigure handling

Also, I made `robot_feedback` dynamically reconfigurable and some consistency improvements (e.g. condition for `input_active`). Further, the acceleration/deceleration limit is now actually considering proper SI units as well as `safe_factor` for both acceleration and deceleration.

Behaviour is still the same:
![fixed_smoother](https://cloud.githubusercontent.com/assets/508006/22894612/f3b34e16-f219-11e6-85bb-11de40441d29.png)
![current_smoother](https://cloud.githubusercontent.com/assets/508006/22894629/fc561c74-f219-11e6-8f9a-41606dfb0ca7.png)

might need to tune the parameters, though due to now actually considering proper units...will test it on robot HW asap.

Requires https://github.com/ipa320/cob_robots/pull/619 due to parameter renaming