### PR TITLE
Configurable base twist controller

### DIFF
--- a/cob_omni_drive_controller/CMakeLists.txt
+++ b/cob_omni_drive_controller/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cob_omni_drive_controller)
 
-find_package(catkin REQUIRED COMPONENTS angles controller_interface geometry_msgs hardware_interface message_generation nav_msgs realtime_tools sensor_msgs std_msgs std_srvs tf urdf)
+find_package(catkin REQUIRED COMPONENTS angles controller_interface dynamic_reconfigure geometry_msgs hardware_interface message_generation nav_msgs realtime_tools sensor_msgs std_msgs std_srvs tf urdf)
 
 find_package(Boost REQUIRED COMPONENTS thread)
 
@@ -13,8 +13,12 @@ add_message_files(
 
 generate_messages(DEPENDENCIES std_msgs)
 
+generate_dynamic_reconfigure_options(
+  cfg/SteerCtrl.cfg
+)
+
 catkin_package(
-  CATKIN_DEPENDS angles controller_interface geometry_msgs hardware_interface message_runtime nav_msgs sensor_msgs std_msgs std_srvs tf urdf
+  CATKIN_DEPENDS angles controller_interface dynamic_reconfigure geometry_msgs hardware_interface message_runtime nav_msgs sensor_msgs std_msgs std_srvs tf urdf
   DEPENDS Boost
   INCLUDE_DIRS include
   LIBRARIES cob_omni_drive_geom cob_omni_drive_controller

--- a/cob_omni_drive_controller/cfg/SteerCtrl.cfg
+++ b/cob_omni_drive_controller/cfg/SteerCtrl.cfg
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+PACKAGE = "cob_omni_drive_controller"
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+# Parameters for tuning Impedance-Controller
+gen.add("spring",     double_t, 0, "Spring-constant (elasticity)",                              15.0,  0.0,  50.0)
+gen.add("damp",       double_t, 0, "Damping coefficient (also prop. for Velocity Feedforward)",  2.75, 0.0,  50.0)
+gen.add("virt_mass",  double_t, 0, "Virtual Mass of Spring-Damper System",                       0.1,  0.0, 200.0)
+gen.add("d_phi_max",  double_t, 0, "maximum angular velocity (cut-off)",                        10.0,  0.0,  50.0)
+gen.add("dd_phi_max", double_t, 0, "maximum angular acceleration (cut-off)",                    40.0,  0.0, 100.0)
+
+# Second arg is node name it will run in (doc purposes only), third is generated filename prefix
+exit(gen.generate(PACKAGE, "steer_control_configure", "SteerCtrl"))

--- a/cob_omni_drive_controller/include/cob_omni_drive_controller/UndercarriageCtrlGeom.h
+++ b/cob_omni_drive_controller/include/cob_omni_drive_controller/UndercarriageCtrlGeom.h
@@ -58,6 +58,8 @@
 #include <string>
 #include <stdexcept>
 
+#include <cob_omni_drive_controller/SteerCtrlConfig.h>
+
 class UndercarriageGeomBase
 {
 public:
@@ -243,6 +245,8 @@ public:
     void reset();
 
     static double limitValue(double value, double limit);
+    
+    bool reconfigureSteerCtrlParams(cob_omni_drive_controller::SteerCtrlConfig& config);
 
 private:
     struct CtrlData : public WheelData {

--- a/cob_omni_drive_controller/include/cob_omni_drive_controller/UndercarriageCtrlGeom.h
+++ b/cob_omni_drive_controller/include/cob_omni_drive_controller/UndercarriageCtrlGeom.h
@@ -58,8 +58,6 @@
 #include <string>
 #include <stdexcept>
 
-#include <cob_omni_drive_controller/SteerCtrlConfig.h>
-
 class UndercarriageGeomBase
 {
 public:
@@ -249,9 +247,9 @@ public:
     void reset();
 
     static double limitValue(double value, double limit);
+    void configure(const std::vector<WheelParams> &params);
+    void configure(const std::vector<UndercarriageCtrl::PosCtrlParams> &pos_ctrls);
     
-    bool reconfigureSteerCtrlParams(cob_omni_drive_controller::SteerCtrlConfig& config);
-
 private:
     struct CtrlData : public WheelData {
         CtrlParams params_;

--- a/cob_omni_drive_controller/include/cob_omni_drive_controller/UndercarriageCtrlGeom.h
+++ b/cob_omni_drive_controller/include/cob_omni_drive_controller/UndercarriageCtrlGeom.h
@@ -203,12 +203,7 @@ private:
 
 class UndercarriageCtrl : public UndercarriageGeomBase {
 public:
-    struct CtrlParams{
-        double dWheelNeutralPos;
-
-        double dMaxDriveRateRadpS;
-        double dMaxSteerRateRadpS;
-
+    struct PosCtrlParams {
         /** ------- Position Controller Steer Wheels -------
         * Impedance-Ctrlr Prms
         *  -> model Stiffness via Spring-Damper-Modell
@@ -220,6 +215,15 @@ public:
         *  m_dDDPhiMax maximum angular acceleration (cut-off)
         */
         double dSpring, dDamp, dVirtM, dDPhiMax, dDDPhiMax;
+    };
+    
+    struct CtrlParams{
+        double dWheelNeutralPos;
+
+        double dMaxDriveRateRadpS;
+        double dMaxSteerRateRadpS;
+        
+        PosCtrlParams pos_ctrl;
     };
 
     struct WheelParams {

--- a/cob_omni_drive_controller/package.xml
+++ b/cob_omni_drive_controller/package.xml
@@ -18,6 +18,7 @@
   <depend>angles</depend>
   <depend>boost</depend>
   <depend>controller_interface</depend>
+  <depend>dynamic_reconfigure</depend>
   <depend>geometry_msgs</depend>
   <depend>hardware_interface</depend>
   <depend>nav_msgs</depend>

--- a/cob_omni_drive_controller/src/GeomController.h
+++ b/cob_omni_drive_controller/src/GeomController.h
@@ -13,11 +13,8 @@ protected:
     std::vector<typename Controller::WheelState> wheel_states_;
     boost::scoped_ptr<Controller> geom_;
 public:
-    bool init(Interface* hw, ros::NodeHandle& controller_nh){
-
-        std::vector<typename Controller::WheelParams> wheel_params;
-        if(!parseWheelParams(wheel_params, controller_nh)) return false;
-
+    typedef std::vector<typename Controller::WheelParams> wheel_params_t;
+    bool init(Interface* hw, const wheel_params_t &wheel_params){
         if (wheel_params.size() < 3){
             ROS_ERROR("At least three wheel are needed.");
             return false;
@@ -37,7 +34,11 @@ public:
         geom_.reset(new Controller(wheel_params));
         return true;
     }
-
+    bool init(Interface* hw, ros::NodeHandle& controller_nh){
+        wheel_params_t wheel_params;
+        if(!parseWheelParams(wheel_params, controller_nh)) return false;
+        return init(hw, wheel_params);
+    }
     void update(){
 
         for (unsigned i=0; i<wheel_states_.size(); i++){

--- a/cob_omni_drive_controller/src/UndercarriageCtrlGeom.cpp
+++ b/cob_omni_drive_controller/src/UndercarriageCtrlGeom.cpp
@@ -54,6 +54,7 @@
 #include <cob_omni_drive_controller/UndercarriageCtrlGeom.h>
 
 #include <math.h>
+#include <assert.h>
 #include <angles/angles.h>
 #include <stdexcept>
 
@@ -236,9 +237,7 @@ void UndercarriageCtrl::CtrlData::reset(){
 }
 
 UndercarriageCtrl::UndercarriageCtrl(const std::vector<WheelParams> &params){
-    for(std::vector<WheelParams>::const_iterator it = params.begin(); it != params.end(); ++it){
-        wheels_.push_back(CtrlData(*it));
-    }
+    configure(params);
 }
 
 void UndercarriageCtrl::calcDirect(PlatformState &state) const{
@@ -273,12 +272,15 @@ void UndercarriageCtrl::reset()
     }
 }
 
-bool UndercarriageCtrl::reconfigureSteerCtrlParams(cob_omni_drive_controller::SteerCtrlConfig& config){
+void UndercarriageCtrl::configure(const std::vector<WheelParams> &params){
+    wheels_.clear();
+    for(std::vector<WheelParams>::const_iterator it = params.begin(); it != params.end(); ++it){
+        wheels_.push_back(CtrlData(*it));
+    }
+}
+void UndercarriageCtrl::configure(const std::vector<UndercarriageCtrl::PosCtrlParams> &pos_ctrls){
+    assert(wheels_.size() == pos_ctrls.size());
     for(size_t i = 0; i < wheels_.size(); ++i){
-        wheels_[i].params_.dSpring = config.spring;
-        wheels_[i].params_.dDamp = config.damp;
-        wheels_[i].params_.dVirtM = config.virt_mass;
-        wheels_[i].params_.dDPhiMax = config.d_phi_max;
-        wheels_[i].params_.dDDPhiMax = config.dd_phi_max;
+        wheels_[i].params_.pos_ctrl= pos_ctrls[i];
     }
 }

--- a/cob_omni_drive_controller/src/UndercarriageCtrlGeom.cpp
+++ b/cob_omni_drive_controller/src/UndercarriageCtrlGeom.cpp
@@ -271,5 +271,14 @@ void UndercarriageCtrl::reset()
     for(size_t i = 0; i < wheels_.size(); ++i){
         wheels_[i].reset();
     }
+}
 
+bool UndercarriageCtrl::reconfigureSteerCtrlParams(cob_omni_drive_controller::SteerCtrlConfig& config){
+    for(size_t i = 0; i < wheels_.size(); ++i){
+        wheels_[i].params_.dSpring = config.spring;
+        wheels_[i].params_.dDamp = config.damp;
+        wheels_[i].params_.dVirtM = config.virt_mass;
+        wheels_[i].params_.dDPhiMax = config.d_phi_max;
+        wheels_[i].params_.dDDPhiMax = config.dd_phi_max;
+    }
 }

--- a/cob_omni_drive_controller/src/UndercarriageCtrlGeom.cpp
+++ b/cob_omni_drive_controller/src/UndercarriageCtrlGeom.cpp
@@ -210,14 +210,14 @@ void UndercarriageCtrl::CtrlData::calcControlStep(WheelCommand &command, double 
     // Impedance-Ctrl
     // Calculate resulting desired forces, velocities
     // double dForceDamp, dForceProp, dAccCmd, dVelCmdInt;
-    double dForceDamp = - params_.dDamp *m_dCtrlVelCmdInt;
-    double dForceProp = params_.dSpring * command.dAngGearSteerRadDelta;
+    double dForceDamp = - params_.pos_ctrl.dDamp *m_dCtrlVelCmdInt;
+    double dForceProp = params_.pos_ctrl.dSpring * command.dAngGearSteerRadDelta;
 
-    double dAccCmd = (dForceDamp + dForceProp) /  params_.dVirtM;
-    dAccCmd = limitValue(dAccCmd, params_.dDDPhiMax);
+    double dAccCmd = (dForceDamp + dForceProp) /  params_.pos_ctrl.dVirtM;
+    dAccCmd = limitValue(dAccCmd, params_.pos_ctrl.dDDPhiMax);
 
     double dVelCmdInt =m_dCtrlVelCmdInt + dCmdRateS * dAccCmd;
-    dVelCmdInt = limitValue(dVelCmdInt, params_.dDPhiMax);
+    dVelCmdInt = limitValue(dVelCmdInt, params_.pos_ctrl.dDPhiMax);
 
     // Store internal ctrlr-states
     m_dCtrlVelCmdInt = dVelCmdInt;

--- a/cob_omni_drive_controller/src/param_parser.cpp
+++ b/cob_omni_drive_controller/src/param_parser.cpp
@@ -72,11 +72,11 @@ bool parseCtrlParams(UndercarriageCtrl::CtrlParams & params, XmlRpc::XmlRpcValue
     }
     XmlRpc::XmlRpcValue &steer = wheel["steer_ctrl"];
 
-    return read(params.dSpring, "spring", steer)
-        && read(params.dDamp, "damp", steer)
-        && read(params.dVirtM, "virt_mass", steer)
-        && read(params.dDPhiMax, "d_phi_max", steer)
-        && read(params.dDDPhiMax, "dd_phi_max", steer);
+    return read(params.pos_ctrl.dSpring, "spring", steer)
+        && read(params.pos_ctrl.dDamp, "damp", steer)
+        && read(params.pos_ctrl.dVirtM, "virt_mass", steer)
+        && read(params.pos_ctrl.dDPhiMax, "d_phi_max", steer)
+        && read(params.pos_ctrl.dDDPhiMax, "dd_phi_max", steer);
 }
 
 bool parseWheelGeom(UndercarriageGeom::WheelGeom & geom, XmlRpc::XmlRpcValue &wheel, MergedXmlRpcStruct &merged, urdf::Model* model){


### PR DESCRIPTION
#includes #134 

related to #91 
For the moment, we can only reconfigure the default values of the SteerCtrl parameters, i.e. the parameters are applied to all wheels...

@ipa-mdl 
Do you see any issue with this implementation regarding interference with the controller read-update-write cycle?