### PR TITLE
Controller interfaces plugin structure

### DIFF
--- a/cob_cartesian_controller/config/example_cartesian_controller.yaml
+++ b/cob_cartesian_controller/config/example_cartesian_controller.yaml
@@ -8,7 +8,7 @@ root_frame: world
 
 # twist controller parameters
 twist_controller:
-  controller_interface: 3    #Velocity 0, Position 1, Trajectory 2, JointStates 3
+  controller_interface: cob_twist_controller/ControllerInterfaceJointStates
 
 # frame_tracker + interactive_marker
 frame_tracker:

--- a/cob_twist_controller/CMakeLists.txt
+++ b/cob_twist_controller/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cob_twist_controller)
 
-find_package(catkin REQUIRED COMPONENTS cmake_modules cob_control_msgs cob_srvs dynamic_reconfigure eigen_conversions geometry_msgs kdl_conversions kdl_parser nav_msgs roscpp roslint sensor_msgs std_msgs tf tf_conversions trajectory_msgs urdf visualization_msgs)
+find_package(catkin REQUIRED COMPONENTS cmake_modules cob_control_msgs cob_srvs dynamic_reconfigure eigen_conversions geometry_msgs kdl_conversions kdl_parser nav_msgs pluginlib roscpp roslint sensor_msgs std_msgs tf tf_conversions trajectory_msgs urdf visualization_msgs)
 
 find_package(Boost REQUIRED COMPONENTS thread)
 
@@ -17,7 +17,7 @@ generate_dynamic_reconfigure_options(
 )
 
 catkin_package(
-  CATKIN_DEPENDS cob_control_msgs cob_srvs dynamic_reconfigure eigen_conversions geometry_msgs kdl_conversions kdl_parser nav_msgs roscpp sensor_msgs std_msgs tf tf_conversions urdf visualization_msgs
+  CATKIN_DEPENDS cob_control_msgs cob_srvs dynamic_reconfigure eigen_conversions geometry_msgs kdl_conversions kdl_parser nav_msgs pluginlib roscpp sensor_msgs std_msgs tf tf_conversions urdf visualization_msgs
   DEPENDS Boost
   INCLUDE_DIRS include
   LIBRARIES damping_methods inv_calculations constraint_solvers limiters controller_interfaces kinematic_extensions inverse_differential_kinematics_solver twist_controller
@@ -29,6 +29,12 @@ include_directories(include ${catkin_INCLUDE_DIRS} ${EIGEN_INCLUDE_DIRS} ${oroco
 set(SRC_C_DIR "src/constraint_solvers")
 set(SRC_CS_DIR "${SRC_C_DIR}/solvers")
 
+## plugin library
+add_library(controller_interfaces src/controller_interfaces/controller_interface.cpp)
+add_dependencies(controller_interfaces ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(controller_interfaces ${catkin_LIBRARIES})
+
+## internal libraries
 add_library(damping_methods src/damping_methods/damping.cpp)
 add_dependencies(damping_methods ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(damping_methods ${catkin_LIBRARIES})
@@ -45,10 +51,6 @@ add_library(limiters src/limiters/limiter.cpp)
 add_dependencies(limiters ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(limiters ${catkin_LIBRARIES} ${orocos_kdl_LIBRARIES})
 
-add_library(controller_interfaces src/controller_interfaces/controller_interface.cpp)
-add_dependencies(controller_interfaces ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-target_link_libraries(controller_interfaces ${catkin_LIBRARIES})
-
 add_library(kinematic_extensions src/kinematic_extensions/kinematic_extension_builder.cpp src/kinematic_extensions/kinematic_extension_dof.cpp src/kinematic_extensions/kinematic_extension_urdf.cpp src/kinematic_extensions/kinematic_extension_lookat.cpp)
 add_dependencies(kinematic_extensions ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(kinematic_extensions ${catkin_LIBRARIES} ${orocos_kdl_LIBRARIES})
@@ -59,7 +61,7 @@ target_link_libraries(inverse_differential_kinematics_solver constraint_solvers 
 
 add_library(twist_controller src/cob_twist_controller.cpp)
 add_dependencies(twist_controller ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-target_link_libraries(twist_controller inverse_differential_kinematics_solver limiters controller_interfaces ${catkin_LIBRARIES} ${orocos_kdl_LIBRARIES})
+target_link_libraries(twist_controller inverse_differential_kinematics_solver limiters ${catkin_LIBRARIES} ${orocos_kdl_LIBRARIES})
 
 add_executable(cob_twist_controller_node src/cob_twist_controller_node.cpp)
 add_dependencies(cob_twist_controller_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
@@ -116,4 +118,8 @@ install(DIRECTORY include/cob_twist_controller/
 
 install(PROGRAMS scripts/test_publisher_twist.py scripts/test_publisher_twist_stamped.py scripts/test_publisher_twist_series.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}/scripts
+)
+
+install(FILES controller_interface_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/cob_twist_controller/cfg/TwistController.cfg
+++ b/cob_twist_controller/cfg/TwistController.cfg
@@ -4,13 +4,6 @@ PACKAGE = "cob_twist_controller"
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
-controller_interface_enum = gen.enum([
-                       gen.const("VELOCITY_INTERFACE",      int_t, 0, "Use VelocityJointInterface. Requires velocity_controllers/joint_group_velocity_controller"),
-                       gen.const("POSITION_INTERFACE",      int_t, 1, "Use PositionJointInterface. Requires position_controllers/joint_group_position_controller"),
-                       gen.const("TRAJECTORY_INTERFACE",    int_t, 2, "Use JointTrajectoryInterface. Requires joint_trajectory_controller"),
-                       gen.const("JOINT_STATE_INTERFACE",   int_t, 3, "Not meant to be used within dynamic reconfigure. Use JointStateInterface.")],
-                     "enum types for the controller interfaces")
-
 damping_method_enum = gen.enum([
                        gen.const("NO_DAMPING",           int_t, 0, "No damping means a damping factor of 0.0."),
                        gen.const("CONSTANT",             int_t, 1, "Constant damping factor given by parameter damping_factor."),
@@ -50,11 +43,6 @@ kinematic_extension_enum = gen.enum([
                        gen.const("COB_TORSO",         int_t, 3, "KinematicExtension for COB_TORSO (any DoF)"),
                        gen.const("LOOKAT",            int_t, 4, "Consider additional DoF of a virtual Lookat component")],
                      "enum types for the kinematic extensions")
-
-# ==================================== Controller interfaces =================================================================================
-ctrl_interface = gen.add_group("Controller Interfaces", "ctrl_interface")
-ctrl_interface.add("controller_interface",   int_t,    0, "The controller interface to use", 0, None, None, edit_method=controller_interface_enum)
-ctrl_interface.add("integrator_smoothing",   double_t, 0, "The factor used for exponential smoothing during simpson integration)",  0.2, 0, 1)
 
 # ==================================== Damping and truncation (singular value adaption) ====================================================
 damp_trunc = gen.add_group("Damping and Truncation", "damping_truncation")

--- a/cob_twist_controller/config/example_cartesian_controller.yaml
+++ b/cob_twist_controller/config/example_cartesian_controller.yaml
@@ -8,7 +8,7 @@ root_frame: world
 
 # twist controller parameters
 twist_controller:
-  controller_interface: 3    #Velocity 0, Position 1, Trajectory 2, JointStates 3
+  controller_interface: cob_twist_controller/ControllerInterfaceJointStates
 
 # frame_tracker + interactive_marker
 frame_tracker:

--- a/cob_twist_controller/controller_interface_plugins.xml
+++ b/cob_twist_controller/controller_interface_plugins.xml
@@ -1,0 +1,14 @@
+<library path="lib/libcontroller_interfaces">
+	<class name="cob_twist_controller/ControllerInterfaceVelocity" type="cob_twist_controller::ControllerInterfaceVelocity" base_class_type="cob_twist_controller::ControllerInterfaceBase">
+		<description> A controller interface publishing target velocities as std_msgs/Float64MultiArray </description>
+	</class>
+	<class name="cob_twist_controller/ControllerInterfacePosition" type="cob_twist_controller::ControllerInterfacePosition" base_class_type="cob_twist_controller::ControllerInterfaceBase">
+		<description> A controller interface publishing target positions as std_msgs/Float64MultiArray </description>
+	</class>
+	<class name="cob_twist_controller/ControllerInterfaceTrajectory" type="cob_twist_controller::ControllerInterfaceTrajectory" base_class_type="cob_twist_controller::ControllerInterfaceBase">
+		<description> A controller interface publishing target positions as trajectory_msgs/JointTrajectory </description>
+	</class>
+	<class name="cob_twist_controller/ControllerInterfaceJointStates" type="cob_twist_controller::ControllerInterfaceJointStates" base_class_type="cob_twist_controller::ControllerInterfaceBase">
+		<description> A controller interface publishing target positions as sensor_msgs/JointStates </description>
+	</class>
+</library>

--- a/cob_twist_controller/include/cob_twist_controller/cob_twist_controller.h
+++ b/cob_twist_controller/include/cob_twist_controller/cob_twist_controller.h
@@ -51,11 +51,12 @@
 #include <boost/shared_ptr.hpp>
 
 #include <dynamic_reconfigure/server.h>
+#include <pluginlib/class_loader.h>
 
 #include <cob_twist_controller/TwistControllerConfig.h>
 #include "cob_twist_controller/cob_twist_controller_data_types.h"
 #include <cob_twist_controller/inverse_differential_kinematics_solver.h>
-#include "cob_twist_controller/controller_interfaces/controller_interface.h"
+#include "cob_twist_controller/controller_interfaces/controller_interface_base.h"
 #include "cob_twist_controller/callback_data_mediator.h"
 
 class CobTwistController
@@ -83,7 +84,8 @@ private:
 
     boost::shared_ptr<KDL::ChainFkSolverVel_recursive> jntToCartSolver_vel_;
     boost::shared_ptr<InverseDifferentialKinematicsSolver> p_inv_diff_kin_solver_;
-    boost::shared_ptr<ControllerInterfaceBase> controller_interface_;
+    boost::shared_ptr<cob_twist_controller::ControllerInterfaceBase> controller_interface_;
+    boost::shared_ptr<pluginlib::ClassLoader<cob_twist_controller::ControllerInterfaceBase> > interface_loader_;
 
     CallbackDataMediator callback_data_mediator_;
 

--- a/cob_twist_controller/include/cob_twist_controller/cob_twist_controller_data_types.h
+++ b/cob_twist_controller/include/cob_twist_controller/cob_twist_controller_data_types.h
@@ -54,14 +54,6 @@ enum DampingMethodTypes
     SIGMOID = cob_twist_controller::TwistController_SIGMOID,
 };
 
-enum ControllerInterfaceTypes
-{
-    VELOCITY_INTERFACE = cob_twist_controller::TwistController_VELOCITY_INTERFACE,
-    POSITION_INTERFACE = cob_twist_controller::TwistController_POSITION_INTERFACE,
-    TRAJECTORY_INTERFACE = cob_twist_controller::TwistController_TRAJECTORY_INTERFACE,
-    JOINT_STATE_INTERFACE = cob_twist_controller::TwistController_JOINT_STATE_INTERFACE,
-};
-
 enum KinematicExtensionTypes
 {
     NO_EXTENSION = cob_twist_controller::TwistController_NO_EXTENSION,
@@ -208,7 +200,7 @@ struct TwistControllerParams
 {
     TwistControllerParams() :
         dof(0),
-        controller_interface(VELOCITY_INTERFACE),
+        controller_interface(""),
         integrator_smoothing(0.2),
 
         numerical_filtering(false),
@@ -250,7 +242,7 @@ struct TwistControllerParams
     std::string chain_base_link;
     std::string chain_tip_link;
 
-    ControllerInterfaceTypes controller_interface;
+    std::string controller_interface;
     double integrator_smoothing;
 
     bool numerical_filtering;

--- a/cob_twist_controller/include/cob_twist_controller/controller_interfaces/controller_interface.h
+++ b/cob_twist_controller/include/cob_twist_controller/controller_interfaces/controller_interface.h
@@ -41,35 +41,20 @@
 
 #include "cob_twist_controller/controller_interfaces/controller_interface_base.h"
 
-/* BEGIN ControllerInterfaceBuilder *****************************************************************************************/
-/// Class providing a static method to create controller interface objects.
-class ControllerInterfaceBuilder
+
+namespace cob_twist_controller
 {
-    public:
-        ControllerInterfaceBuilder() {}
-        ~ControllerInterfaceBuilder() {}
-
-        static ControllerInterfaceBase* createControllerInterface(ros::NodeHandle& nh,
-                                                                  const TwistControllerParams& params,
-                                                                  const JointStates& joint_states);
-};
-/* END ControllerInterfaceBuilder *******************************************************************************************/
-
 
 /* BEGIN ControllerInterfaceVelocity ****************************************************************************************/
 /// Class providing a ControllerInterface publishing velocities.
 class ControllerInterfaceVelocity : public ControllerInterfaceBase
 {
     public:
-        explicit ControllerInterfaceVelocity(ros::NodeHandle& nh,
-                                             const TwistControllerParams& params)
-        : ControllerInterfaceBase(nh, params)
-        {
-            pub_ = nh.advertise<std_msgs::Float64MultiArray>("joint_group_velocity_controller/command", 1);
-        }
-
+        ControllerInterfaceVelocity() {}
         ~ControllerInterfaceVelocity() {}
 
+        virtual void initialize(ros::NodeHandle& nh,
+                                const TwistControllerParams& params);
         virtual void processResult(const KDL::JntArray& q_dot_ik,
                                    const KDL::JntArray& current_q);
 };
@@ -81,15 +66,11 @@ class ControllerInterfaceVelocity : public ControllerInterfaceBase
 class ControllerInterfacePosition : public ControllerInterfacePositionBase
 {
     public:
-        explicit ControllerInterfacePosition(ros::NodeHandle& nh,
-                                             const TwistControllerParams& params)
-        : ControllerInterfacePositionBase(nh, params)
-        {
-            pub_ = nh.advertise<std_msgs::Float64MultiArray>("joint_group_position_controller/command", 1);
-        }
-
+        ControllerInterfacePosition() {}
         ~ControllerInterfacePosition() {}
 
+        virtual void initialize(ros::NodeHandle& nh,
+                                const TwistControllerParams& params);
         virtual void processResult(const KDL::JntArray& q_dot_ik,
                                    const KDL::JntArray& current_q);
 };
@@ -101,15 +82,11 @@ class ControllerInterfacePosition : public ControllerInterfacePositionBase
 class ControllerInterfaceTrajectory : public ControllerInterfacePositionBase
 {
     public:
-        explicit ControllerInterfaceTrajectory(ros::NodeHandle& nh,
-                                               const TwistControllerParams& params)
-        : ControllerInterfacePositionBase(nh, params)
-        {
-            pub_ = nh.advertise<trajectory_msgs::JointTrajectory>("joint_trajectory_controller/command", 1);
-        }
-
+        ControllerInterfaceTrajectory() {}
         ~ControllerInterfaceTrajectory() {}
 
+        virtual void initialize(ros::NodeHandle& nh,
+                                const TwistControllerParams& params);
         virtual void processResult(const KDL::JntArray& q_dot_ik,
                                    const KDL::JntArray& current_q);
 };
@@ -120,31 +97,11 @@ class ControllerInterfaceTrajectory : public ControllerInterfacePositionBase
 class ControllerInterfaceJointStates : public ControllerInterfacePositionBase
 {
     public:
-        explicit ControllerInterfaceJointStates(ros::NodeHandle& nh,
-                                                const TwistControllerParams& params,
-                                                const JointStates& joint_states)
-        : ControllerInterfacePositionBase(nh, params)
-        {
-            pub_ = nh.advertise<sensor_msgs::JointState>("joint_states", 1);
-
-            js_msg_.name = params_.joints;
-            js_msg_.position.clear();
-            js_msg_.velocity.clear();
-            js_msg_.effort.clear();
-
-            for (unsigned int i=0; i < joint_states.current_q_.rows(); i++)
-            {
-                js_msg_.position.push_back(joint_states.current_q_(i));
-                js_msg_.velocity.push_back(joint_states.current_q_dot_(i));
-                js_msg_.effort.push_back(0.0);
-            }
-
-            js_timer_ = nh.createTimer(ros::Duration(1/50.0), &ControllerInterfaceJointStates::publishJointState, this);
-            js_timer_.start();
-        }
-
+        ControllerInterfaceJointStates() {}
         ~ControllerInterfaceJointStates() {}
 
+        virtual void initialize(ros::NodeHandle& nh,
+                                const TwistControllerParams& params);
         virtual void processResult(const KDL::JntArray& q_dot_ik,
                                    const KDL::JntArray& current_q);
 
@@ -156,5 +113,7 @@ class ControllerInterfaceJointStates : public ControllerInterfacePositionBase
         void publishJointState(const ros::TimerEvent& event);
 };
 /* END ControllerInterfaceJointStates **********************************************************************************************/
+
+}
 
 #endif  // COB_TWIST_CONTROLLER_CONTROLLER_INTERFACES_CONTROLLER_INTERFACE_H

--- a/cob_twist_controller/package.xml
+++ b/cob_twist_controller/package.xml
@@ -33,6 +33,7 @@
   <depend>kdl_parser</depend>
   <depend>nav_msgs</depend>
   <depend>orocos_kdl</depend>
+  <depend>pluginlib</depend>
   <depend>roscpp</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
@@ -49,4 +50,7 @@
   <exec_depend>topic_tools</exec_depend>
   <exec_depend>xacro</exec_depend>
 
+  <export>
+    <cob_twist_controller plugin="${prefix}/controller_interface_plugins.xml"/>
+  </export>
 </package>

--- a/cob_twist_controller/scripts/test/test_careobot_GPM_jla_ca_torus.py
+++ b/cob_twist_controller/scripts/test/test_careobot_GPM_jla_ca_torus.py
@@ -44,7 +44,6 @@ from data_collection import FrameTrackingDataKraken
 def init_dyn_recfg():
     cli = tcc.TwistControllerReconfigureClient()
     cli.init()
-    cli.set_config_param(tcc.CTRL_IF, tcc.TwistController_VELOCITY_INTERFACE)
 
     cli.set_config_param(tcc.DAMP_METHOD, tcc.TwistController_MANIPULABILITY)
     cli.set_config_param(tcc.LAMBDA_MAX, 0.1)

--- a/cob_twist_controller/scripts/test/test_careobot_base.py
+++ b/cob_twist_controller/scripts/test/test_careobot_base.py
@@ -47,7 +47,6 @@ from data_collection import OdometryDataKraken
 def init_dyn_recfg():
     cli = tcc.TwistControllerReconfigureClient()
     cli.init()
-    cli.set_config_param(tcc.CTRL_IF, tcc.TwistController_VELOCITY_INTERFACE)
 
     cli.set_config_param(tcc.NUM_FILT, False)
     cli.set_config_param(tcc.DAMP_METHOD, tcc.TwistController_CONSTANT)

--- a/cob_twist_controller/scripts/test/test_careobot_st_jla_ca_selfcollision_arm_left_direct_head.py
+++ b/cob_twist_controller/scripts/test/test_careobot_st_jla_ca_selfcollision_arm_left_direct_head.py
@@ -44,7 +44,6 @@ from data_collection import FrameTrackingDataKraken
 def init_dyn_recfg():
     cli = tcc.TwistControllerReconfigureClient()
     cli.init()
-    cli.set_config_param(tcc.CTRL_IF, tcc.TwistController_VELOCITY_INTERFACE)
 
     cli.set_config_param(tcc.NUM_FILT, False)
     cli.set_config_param(tcc.DAMP_METHOD, tcc.TwistController_MANIPULABILITY)

--- a/cob_twist_controller/scripts/test/test_careobot_st_jla_ca_selfcollision_arm_left_internal_motion.py
+++ b/cob_twist_controller/scripts/test/test_careobot_st_jla_ca_selfcollision_arm_left_internal_motion.py
@@ -44,7 +44,6 @@ from data_collection import FrameTrackingDataKraken
 def init_dyn_recfg():
     cli = tcc.TwistControllerReconfigureClient()
     cli.init()
-    cli.set_config_param(tcc.CTRL_IF, tcc.TwistController_VELOCITY_INTERFACE)
 
     cli.set_config_param(tcc.NUM_FILT, False)
     cli.set_config_param(tcc.DAMP_METHOD, tcc.TwistController_MANIPULABILITY)

--- a/cob_twist_controller/scripts/test/test_careobot_st_jla_ca_sphere.py
+++ b/cob_twist_controller/scripts/test/test_careobot_st_jla_ca_sphere.py
@@ -43,7 +43,6 @@ from data_collection import FrameTrackingDataKraken
 def init_dyn_recfg():
     cli = tcc.TwistControllerReconfigureClient()
     cli.init()
-    cli.set_config_param(tcc.CTRL_IF, tcc.TwistController_VELOCITY_INTERFACE)
 
     cli.set_config_param(tcc.DAMP_METHOD, tcc.TwistController_MANIPULABILITY)
     cli.set_config_param(tcc.LAMBDA_MAX, 0.1)

--- a/cob_twist_controller/scripts/test/test_careobot_st_jla_ca_torus.py
+++ b/cob_twist_controller/scripts/test/test_careobot_st_jla_ca_torus.py
@@ -44,7 +44,6 @@ from data_collection import FrameTrackingDataKraken
 def init_dyn_recfg():
     cli = tcc.TwistControllerReconfigureClient()
     cli.init()
-    cli.set_config_param(tcc.CTRL_IF, tcc.TwistController_VELOCITY_INTERFACE)
 
     cli.set_config_param(tcc.NUM_FILT, False)
     cli.set_config_param(tcc.DAMP_METHOD, tcc.TwistController_MANIPULABILITY)

--- a/cob_twist_controller/scripts/test/test_raw31.py
+++ b/cob_twist_controller/scripts/test/test_raw31.py
@@ -54,7 +54,6 @@ pub = rospy.Publisher('/arm/joint_trajectory_controller/command', JointTrajector
 def init_dyn_recfg():
     cli = tcc.TwistControllerReconfigureClient()
     cli.init()
-    cli.set_config_param(tcc.CTRL_IF, tcc.TwistController_VELOCITY_INTERFACE)
 
     cli.set_config_param(tcc.NUM_FILT, False)
     cli.set_config_param(tcc.DAMP_METHOD, tcc.TwistController_MANIPULABILITY)

--- a/cob_twist_controller/src/twist_controller_config/twist_controller_config.py
+++ b/cob_twist_controller/src/twist_controller_config/twist_controller_config.py
@@ -32,8 +32,6 @@ from cob_twist_controller.cfg.TwistControllerConfig import *
 '''
 Available keys for the dynamic_reconfigure update call
 '''
-CTRL_IF = 'controller_interface'
-
 NUM_FILT = 'numerical_filtering'
 DAMP_METHOD = 'damping_method'
 DAMP_FACT = 'damping_factor'


### PR DESCRIPTION
This PR introduces a plugin structure for the controller_interfaces of `cob_twist_controller`.
All previous interfaces (JointGroupVelocity, JointGroupPosition, JointTrajectory and JointStates) are available unchanged....but this PR now allows to implement new controller_interfaces that we do not want to integrate into `cob_twist_controller` package

Do not merge yet as we need to update the `X_cartesian_controller.yaml` files in `cob_hardware_config` and `schunk_robots`

@ipa-bfb please test and review