### PR TITLE
Fixed wrong velocity used for linear y

### DIFF
--- a/cob_base_velocity_smoother/src/cob_base_velocity_smoother/velocity_smoother.cpp
+++ b/cob_base_velocity_smoother/src/cob_base_velocity_smoother/velocity_smoother.cpp
@@ -222,7 +222,7 @@ void VelocitySmoother::spin()
       }
       else
       {
-        max_vy_inc = ((vy_inc*target_vel.linear.x > 0.0)?accel_lim_vy:decel_vy)*period;
+        max_vy_inc = ((vy_inc*target_vel.linear.y > 0.0)?accel_lim_vy:decel_vy)*period;
       }
 
       w_inc = target_vel.angular.z - last_cmd_vel.angular.z;


### PR DESCRIPTION
Wrong velocity was used when computing max_vy_inc