### PR TITLE
use fabs for distances in omni controller

### DIFF
--- a/cob_omni_drive_controller/src/param_parser.cpp
+++ b/cob_omni_drive_controller/src/param_parser.cpp
@@ -176,8 +176,8 @@ bool parseWheelGeom(WheelGeom & geom, XmlRpc::XmlRpcValue &wheel, MergedXmlRpcSt
 
     ROS_DEBUG_STREAM(geom.steer_name<<" steer_pos \tx:"<<steer_pos.x<<" \ty:"<<steer_pos.y<<" \tz:"<<steer_pos.z);
 
-    geom.dWheelXPosMM = steer_pos.x * 1000;
-    geom.dWheelYPosMM = steer_pos.y * 1000;
+    geom.dWheelXPosMM = fabs(steer_pos.x * 1000);
+    geom.dWheelYPosMM = fabs(steer_pos.y * 1000);
     geom.dRadiusWheelMM = fabs(steer_pos.z * 1000);
 
     double offset = 0;


### PR DESCRIPTION
I think this is the proper fix for https://github.com/mojin-robotics/cob4/issues/983 and supersedes #194 

Testing:
 - [ ] omni forward
 - [ ] omni backward
 - [ ] tricycle forward
 - [ ] tricycle backward