### PR TITLE
Melodify/cob cobstacle distance

### DIFF
--- a/cob_obstacle_distance/include/cob_obstacle_distance/chainfk_solvers/advanced_chainfksolver_recursive.hpp
+++ b/cob_obstacle_distance/include/cob_obstacle_distance/chainfk_solvers/advanced_chainfksolver_recursive.hpp
@@ -81,13 +81,14 @@ class AdvancedChainFkSolverVel_recursive : public KDL::ChainFkSolverVel
          * @return An error code (0 == success)
          */
         virtual int JntToCart(const KDL::JntArrayVel& q_in, KDL::FrameVel& out, int seg_nr = -1);
+        virtual int JntToCart(const KDL::JntArrayVel& q_in, std::vector<KDL::FrameVel>& out, int segmentNr = -1);
 
         /**
          * @param seg_idx Index of the segment starting with 0.
          * @return The reference frame of the segment.
          */
         KDL::FrameVel getFrameVelAtSegment(uint16_t seg_idx) const;
-
+        virtual void updateInternalDataStructures(){};
 
     private:
         const KDL::Chain& chain_;

--- a/cob_obstacle_distance/include/cob_obstacle_distance/link_to_collision.hpp
+++ b/cob_obstacle_distance/include/cob_obstacle_distance/link_to_collision.hpp
@@ -47,15 +47,15 @@
 class LinkToCollision
 {
     private:
-        typedef boost::shared_ptr<const urdf::Link> PtrConstLink_t;
-        typedef boost::shared_ptr<urdf::Link> PtrLink_t;
-        typedef std::vector<boost::shared_ptr<urdf::Link> > VecPtrLink_t;
-        typedef boost::shared_ptr<urdf::Collision> PtrCollision_t;
-        typedef boost::shared_ptr<urdf::Geometry> PtrGeometry_t;
-        typedef boost::shared_ptr<urdf::Mesh> PtrMesh_t;
-        typedef boost::shared_ptr<urdf::Box> PtrBox_t;
-        typedef boost::shared_ptr<urdf::Sphere> PtrSphere_t;
-        typedef boost::shared_ptr<urdf::Cylinder> PtrCylinder_t;
+        typedef urdf::LinkConstSharedPtr PtrConstLink_t;
+        typedef urdf::LinkSharedPtr PtrLink_t;
+        typedef std::vector<PtrLink_t> VecPtrLink_t;
+        typedef urdf::CollisionSharedPtr PtrCollision_t;
+        typedef urdf::GeometrySharedPtr PtrGeometry_t;
+        typedef urdf::MeshSharedPtr PtrMesh_t;
+        typedef urdf::BoxSharedPtr PtrBox_t;
+        typedef urdf::SphereSharedPtr PtrSphere_t;
+        typedef urdf::CylinderSharedPtr PtrCylinder_t;
         typedef std::unordered_map<std::string, std::vector<std::string> >::iterator MapIter_t;
 
         urdf::Model model_;

--- a/cob_obstacle_distance/src/debug/debug_obstacle_distance_node.cpp
+++ b/cob_obstacle_distance/src/debug/debug_obstacle_distance_node.cpp
@@ -108,7 +108,9 @@ public:
             marker_distance.ns = it->first;
             marker_distance.id = 69;
             marker_distance.header.frame_id = chain_base_link_;
-            marker_distance.text = boost::lexical_cast<std::string>(boost::format("%.3f") % it->second.distance);
+            std::stringstream sstream;
+            sstream << std::setprecision(3) << it->second.distance;
+            marker_distance.text = sstream.str();
 
             marker_distance.scale.x = 0.1;
             marker_distance.scale.y = 0.1;


### PR DESCRIPTION
api of kdl changed and now offers/requires a) updateInternalDataStructures and b) an extended version of JntToCart to be implemented. With the new melodic api (Version 1.4.0) in theory the Advanced..recursive solvers get obsolete, but to keep backward compatiblity I copied the newly added functions. They are unused however