### PR TITLE
[melodic] add emulation_clock publisher

### DIFF
--- a/cob_hardware_emulation/CMakeLists.txt
+++ b/cob_hardware_emulation/CMakeLists.txt
@@ -7,6 +7,7 @@ catkin_package()
 
 catkin_install_python(PROGRAMS
   scripts/emulation_base.py
+  scripts/emulation_clock.py
   scripts/emulation_follow_joint_trajectory.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/cob_hardware_emulation/package.xml
+++ b/cob_hardware_emulation/package.xml
@@ -14,6 +14,7 @@
   <exec_depend>actionlib</exec_depend>
   <exec_depend>control_msgs</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
+  <exec_depend>rosgraph_msgs</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_srvs</exec_depend>

--- a/cob_hardware_emulation/scripts/emulation_clock.py
+++ b/cob_hardware_emulation/scripts/emulation_clock.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import time
+import rospy
+from rosgraph_msgs.msg import Clock
+
+rospy.init_node('emulation_clock', disable_rostime=True)
+pub = rospy.Publisher('/clock', Clock, queue_size=1)
+time_factor = rospy.get_param('/emulation_time_factor', 1.0)
+if not time_factor > 0.0:
+    rospy.logerr("emulation_time_factor must be >0.0, but is {}. exiting...".format(time_factor))
+    exit(-1)
+
+t = time.time()
+dt = 0.01
+while not rospy.is_shutdown():
+    t+=dt*time_factor
+    msg = Clock()
+    msg.clock = rospy.Time(t)
+    pub.publish(msg)
+    time.sleep(dt)

--- a/cob_hardware_emulation/scripts/emulation_clock.py
+++ b/cob_hardware_emulation/scripts/emulation_clock.py
@@ -4,18 +4,25 @@ import time
 import rospy
 from rosgraph_msgs.msg import Clock
 
-rospy.init_node('emulation_clock', disable_rostime=True)
-pub = rospy.Publisher('/clock', Clock, queue_size=1)
-time_factor = rospy.get_param('/emulation_time_factor', 1.0)
-if not time_factor > 0.0:
-    rospy.logerr("emulation_time_factor must be >0.0, but is {}. exiting...".format(time_factor))
-    exit(-1)
+class EmulationClock(object):
+    def __init__(self):
+        self.t = time.time()
+        self.dt = 0.01
+        self.time_factor = rospy.get_param('/emulation_time_factor', 1.0)
+        if not self.time_factor > 0.0:
+            rospy.logerr("emulation_time_factor must be >0.0, but is {}. exiting...".format(self.time_factor))
+            exit(-1)
+        self.pub = rospy.Publisher('/clock', Clock, queue_size=1)
+        rospy.Timer(rospy.Duration(self.dt), self.timer_cb)
 
-t = time.time()
-dt = 0.01
-while not rospy.is_shutdown():
-    t+=dt*time_factor
-    msg = Clock()
-    msg.clock = rospy.Time(t)
-    pub.publish(msg)
-    time.sleep(dt)
+    def timer_cb(self, event):
+        self.t+=self.dt*self.time_factor
+        msg = Clock()
+        msg.clock = rospy.Time(self.t)
+        self.pub.publish(msg)
+
+
+if __name__ == '__main__':
+    rospy.init_node('emulation_clock', disable_rostime=True)
+    EmulationClock()
+    rospy.spin()


### PR DESCRIPTION
same as #232 for melodic
this is just to sync `cob_control/melodic_dev` to `cob_control/kinetic_dev`

I'm not yet happy with the performance - which is why #232 should not have been merged...