### PR TITLE
[kinetic] fix fjt emulation

### DIFF
--- a/cob_hardware_emulation/scripts/emulation_follow_joint_trajectory.py
+++ b/cob_hardware_emulation/scripts/emulation_follow_joint_trajectory.py
@@ -77,6 +77,11 @@ class EmulationFollowJointTrajectory(object):
                     self.as_fjta.set_aborted()
                     return
 
+                point_time_delta = point.time_from_start - time_since_start_of_previous_point
+                if point_time_delta.to_sec() < self.sample_rate_dur_secs:
+                    rospy.logwarn("current trajectory point has time_delta smaller than sample_rate: {} < {}! Skipping".format(point_time_delta.to_sec(), self.sample_rate_dur_secs))
+                    continue
+
                 # we need to resort the positions array because moveit sorts alphabetically but all other ROS components sort in the URDF order
                 positions_sorted = []
                 for joint_name in self.joint_names:


### PR DESCRIPTION
fjt emulator failed to successfully execute trajectories from moveit because the trajectory points had time deltas smaller than the fjt emulator update rate

this pr provides two fixes:
- allow update rate to be increased via parameter
- skip trajectory points being too close