### PR TITLE
ROS_PYTHON_VERSION conditional dependency for python-six

### DIFF
--- a/cob_twist_controller/package.xml
+++ b/cob_twist_controller/package.xml
@@ -42,8 +42,6 @@
   <depend condition="$ROS_DISTRO == noetic">liborocos-kdl-dev</depend>
   <depend condition="$ROS_DISTRO == noetic">liborocos-kdl</depend>
   <depend>pluginlib</depend>
-  <depend condition="$ROS_PYTHON_VERSION == 2">python-six</depend>
-  <depend condition="$ROS_PYTHON_VERSION == 3">python3-six</depend>
   <depend>roscpp</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
@@ -57,6 +55,8 @@
   <exec_depend>cob_script_server</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-matplotlib</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-matplotlib</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-six</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-six</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>rviz</exec_depend>

--- a/cob_twist_controller/package.xml
+++ b/cob_twist_controller/package.xml
@@ -42,7 +42,8 @@
   <depend condition="$ROS_DISTRO == noetic">liborocos-kdl-dev</depend>
   <depend condition="$ROS_DISTRO == noetic">liborocos-kdl</depend>
   <depend>pluginlib</depend>
-  <depend>python-six</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 2">python-six</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 3">python3-six</depend>
   <depend>roscpp</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>


### PR DESCRIPTION
Introspecting Python 2 dependencies in ROS Noetic, found that this package depends on `python-six` instead of its python3 counterpart.

This PR makes the dependency conditional on the ROS_PYTHON_VERSION.
SImilar to https://github.com/ipa320/cob_command_tools/pull/302

This is a semi-automated PR that has not been tested