### PR TITLE
fcl noetic compatibility

### DIFF
--- a/.travis.rosinstall.noetic
+++ b/.travis.rosinstall.noetic
@@ -1,8 +1,0 @@
-- git:
-    local-name: cob_command_tools
-    uri: https://github.com/ipa320/cob_command_tools.git
-    version: indigo_dev
-- git:
-    local-name: cob_driver
-    uri: https://github.com/ipa320/cob_driver.git
-    version: kinetic_dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - ROS_REPO=main
   matrix:
     - ROS_DISTRO=melodic
-    - ROS_DISTRO=noetic UPSTREAM_WORKSPACE='.travis.rosinstall.noetic -cob_command_tools/cob_command_gui -cob_command_tools/cob_command_tools' CATKIN_LINT_ARGS='--ignore description_boilerplate --ignore target_name_collision --ignore unknown_package'
+    - ROS_DISTRO=noetic
 install:
   - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci -b master
 script:

--- a/cob_obstacle_distance/include/cob_obstacle_distance/fcl_marker_converter.hpp
+++ b/cob_obstacle_distance/include/cob_obstacle_distance/fcl_marker_converter.hpp
@@ -19,9 +19,25 @@
 #define FCL_MARKER_CONVERTER_HPP_
 
 #include <boost/scoped_ptr.hpp>
-#include <fcl/shape/geometric_shapes.h>
-#include <fcl/BVH/BVH_model.h>
-#include <fcl/shape/geometric_shape_to_BVH_model.h>
+
+#include <fcl/config.h>
+#if FCL_MINOR_VERSION == 5
+    #include <fcl/shape/geometric_shapes.h>
+    #include <fcl/BVH/BVH_model.h>
+    #include <fcl/shape/geometric_shape_to_BVH_model.h>
+    typedef fcl::Box FCL_Box;
+    typedef fcl::Sphere FCL_Sphere;
+    typedef fcl::Cylinder FCL_Cylinder;
+#else
+    #include <fcl/geometry/shape/box.h>
+    #include <fcl/geometry/shape/sphere.h>
+    #include <fcl/geometry/shape/cylinder.h>
+    #include <fcl/geometry/bvh/BVH_model.h>
+    #include <fcl/geometry/geometric_shape_to_BVH_model.h>
+    typedef fcl::Boxf FCL_Box;
+    typedef fcl::Spheref FCL_Sphere;
+    typedef fcl::Cylinderf FCL_Cylinder;
+#endif
 
 
 #include "cob_obstacle_distance/marker_shapes/marker_shapes_interface.hpp"
@@ -43,16 +59,16 @@ class FclMarkerConverter
 };
 
 template<>
-class FclMarkerConverter<fcl::Box>
+class FclMarkerConverter<FCL_Box>
 {
-    typedef boost::scoped_ptr<fcl::Box> sPtrBox;
+    typedef boost::scoped_ptr<FCL_Box> sPtrBox;
 
     private:
-        fcl::Box geo_shape_;
+        FCL_Box geo_shape_;
 
     public:
-        FclMarkerConverter() : geo_shape_(fcl::Box(1.0, 1.0, 1.0)) {}
-        FclMarkerConverter(fcl::Box& box) : geo_shape_(box) {}
+        FclMarkerConverter() : geo_shape_(FCL_Box(1.0, 1.0, 1.0)) {}
+        FclMarkerConverter(FCL_Box& box) : geo_shape_(box) {}
 
         void assignValues(visualization_msgs::Marker& marker)
         {
@@ -62,7 +78,7 @@ class FclMarkerConverter<fcl::Box>
             marker.type = visualization_msgs::Marker::CUBE;
         }
 
-        fcl::Box getGeoShape() const
+        FCL_Box getGeoShape() const
         {
             return geo_shape_;
         }
@@ -75,16 +91,16 @@ class FclMarkerConverter<fcl::Box>
 };
 
 template<>
-class FclMarkerConverter<fcl::Sphere>
+class FclMarkerConverter<FCL_Sphere>
 {
-    typedef boost::scoped_ptr<fcl::Sphere> sPtrSphere;
+    typedef boost::scoped_ptr<FCL_Sphere> sPtrSphere;
 
     private:
-        fcl::Sphere geo_shape_;
+        FCL_Sphere geo_shape_;
 
     public:
-        FclMarkerConverter() : geo_shape_(fcl::Sphere(1.0)) {}
-        FclMarkerConverter(fcl::Sphere &sphere) : geo_shape_(sphere) {}
+        FclMarkerConverter() : geo_shape_(FCL_Sphere(1.0)) {}
+        FclMarkerConverter(FCL_Sphere &sphere) : geo_shape_(sphere) {}
 
         void assignValues(visualization_msgs::Marker &marker)
         {
@@ -94,7 +110,7 @@ class FclMarkerConverter<fcl::Sphere>
             marker.type = visualization_msgs::Marker::SPHERE;
         }
 
-        fcl::Sphere getGeoShape() const
+        FCL_Sphere getGeoShape() const
         {
             return geo_shape_;
         }
@@ -113,16 +129,16 @@ class FclMarkerConverter<fcl::Sphere>
 };
 
 template<>
-class FclMarkerConverter<fcl::Cylinder>
+class FclMarkerConverter<FCL_Cylinder>
 {
-    typedef boost::scoped_ptr<fcl::Cylinder> sPtrCylinder;
+    typedef boost::scoped_ptr<FCL_Cylinder> sPtrCylinder;
 
     private:
-        fcl::Cylinder geo_shape_;
+        FCL_Cylinder geo_shape_;
 
     public:
-        FclMarkerConverter() : geo_shape_(fcl::Cylinder(1.0, 1.0)) {}
-        FclMarkerConverter(fcl::Cylinder &cyl) : geo_shape_(cyl) {}
+        FclMarkerConverter() : geo_shape_(FCL_Cylinder(1.0, 1.0)) {}
+        FclMarkerConverter(FCL_Cylinder &cyl) : geo_shape_(cyl) {}
 
         void assignValues(visualization_msgs::Marker &marker)
         {
@@ -132,7 +148,7 @@ class FclMarkerConverter<fcl::Cylinder>
             marker.type = visualization_msgs::Marker::CYLINDER;
         }
 
-        fcl::Cylinder getGeoShape() const
+        FCL_Cylinder getGeoShape() const
         {
             return geo_shape_;
         }

--- a/cob_obstacle_distance/include/cob_obstacle_distance/link_to_collision.hpp
+++ b/cob_obstacle_distance/include/cob_obstacle_distance/link_to_collision.hpp
@@ -28,11 +28,6 @@
 #include <boost/scoped_ptr.hpp>
 #include <boost/pointer_cast.hpp>
 
-#include <fcl/collision_object.h>
-#include <fcl/collision.h>
-#include <fcl/distance.h>
-#include <fcl/collision_data.h>
-
 #include <std_msgs/ColorRGBA.h>
 #include <geometry_msgs/Vector3.h>
 #include <geometry_msgs/Quaternion.h>

--- a/cob_obstacle_distance/include/cob_obstacle_distance/marker_shapes/marker_shapes.hpp
+++ b/cob_obstacle_distance/include/cob_obstacle_distance/marker_shapes/marker_shapes.hpp
@@ -23,14 +23,17 @@
 #include <shape_msgs/Mesh.h>
 #include <shape_msgs/MeshTriangle.h>
 
-#include "fcl/shape/geometric_shapes.h"
-#include "fcl/collision_object.h"
+#include <fcl/config.h>
+#if FCL_MINOR_VERSION == 5
+    #include "fcl/collision_object.h"
+    typedef fcl::CollisionObject FCL_CollisionObject;
+#else
+    #include <fcl/narrowphase/collision_object.h>
+    typedef fcl::CollisionObjectf FCL_CollisionObject;
+#endif
 
 #include "cob_obstacle_distance/fcl_marker_converter.hpp"
 #include "cob_obstacle_distance/marker_shapes/marker_shapes_interface.hpp"
-
-#include <fcl/distance.h>
-#include <fcl/collision_data.h>
 
 static const std::string g_marker_namespace = "collision_object";
 
@@ -92,9 +95,9 @@ class MarkerShape : public IMarkerShape
         inline void updatePose(const geometry_msgs::Pose& pose);
 
         /**
-         * @return A fcl::CollisionObject to calculate distances to other objects or check whether collision occurred or not.
+         * @return A FCL_CollisionObject to calculate distances to other objects or check whether collision occurred or not.
          */
-        fcl::CollisionObject getCollisionObject() const;
+        FCL_CollisionObject getCollisionObject() const;
 
         virtual ~MarkerShape(){}
 };
@@ -155,9 +158,9 @@ class MarkerShape<BVH_RSS_t> : public IMarkerShape
         inline void updatePose(const geometry_msgs::Pose& pose);
 
         /**
-         * @return A fcl::CollisionObject to calculate distances to other objects or check whether collision occurred or not.
+         * @return A FCL_CollisionObject to calculate distances to other objects or check whether collision occurred or not.
          */
-        fcl::CollisionObject getCollisionObject() const;
+        FCL_CollisionObject getCollisionObject() const;
 
         virtual ~MarkerShape(){}
 };

--- a/cob_obstacle_distance/include/cob_obstacle_distance/marker_shapes/marker_shapes_impl.hpp
+++ b/cob_obstacle_distance/include/cob_obstacle_distance/marker_shapes/marker_shapes_impl.hpp
@@ -18,6 +18,15 @@
 #ifndef MARKER_SHAPES_IMPL_HPP_
 #define MARKER_SHAPES_IMPL_HPP_
 
+#include <fcl/config.h>
+#if FCL_MINOR_VERSION == 5
+    typedef fcl::Vec3f FCL_Vec3;
+    typedef fcl::Quaternion3f FCL_Quaternion;
+#else
+    typedef fcl::Vector3f FCL_Vec3;
+    typedef fcl::Quaternionf FCL_Quaternion;
+#endif
+
 #include "cob_obstacle_distance/marker_shapes/marker_shapes.hpp"
 
 /* BEGIN MarkerShape ********************************************************************************************/
@@ -115,16 +124,17 @@ inline visualization_msgs::Marker MarkerShape<T>::getMarker()
 
 
 template <typename T>
-fcl::CollisionObject MarkerShape<T>::getCollisionObject() const
+FCL_CollisionObject MarkerShape<T>::getCollisionObject() const
 {
-    fcl::Transform3f x(fcl::Quaternion3f(this->marker_.pose.orientation.w,
-                                         this->marker_.pose.orientation.x,
-                                         this->marker_.pose.orientation.y,
-                                         this->marker_.pose.orientation.z),
-                       fcl::Vec3f(this->marker_.pose.position.x,
-                                  this->marker_.pose.position.y,
-                                  this->marker_.pose.position.z));
-    fcl::CollisionObject cobj(this->ptr_fcl_bvh_, x);
+    fcl::Transform3f x(FCL_Quaternion(this->marker_.pose.orientation.w,
+                                      this->marker_.pose.orientation.x,
+                                      this->marker_.pose.orientation.y,
+                                      this->marker_.pose.orientation.z),
+                        FCL_Vec3(this->marker_.pose.position.x,
+                                 this->marker_.pose.position.y,
+                                 this->marker_.pose.position.z));
+
+    FCL_CollisionObject cobj(this->ptr_fcl_bvh_, x);
     return cobj;
 }
 

--- a/cob_obstacle_distance/include/cob_obstacle_distance/marker_shapes/marker_shapes_impl.hpp
+++ b/cob_obstacle_distance/include/cob_obstacle_distance/marker_shapes/marker_shapes_impl.hpp
@@ -126,13 +126,18 @@ inline visualization_msgs::Marker MarkerShape<T>::getMarker()
 template <typename T>
 FCL_CollisionObject MarkerShape<T>::getCollisionObject() const
 {
+    // FIXME
+    // fcl::Transform3f x(FCL_Quaternion(this->marker_.pose.orientation.w,
+    //                                   this->marker_.pose.orientation.x,
+    //                                   this->marker_.pose.orientation.y,
+    //                                   this->marker_.pose.orientation.z),
+    //                     FCL_Vec3(this->marker_.pose.position.x,
+    //                              this->marker_.pose.position.y,
+    //                              this->marker_.pose.position.z));
     fcl::Transform3f x(FCL_Quaternion(this->marker_.pose.orientation.w,
                                       this->marker_.pose.orientation.x,
                                       this->marker_.pose.orientation.y,
-                                      this->marker_.pose.orientation.z),
-                        FCL_Vec3(this->marker_.pose.position.x,
-                                 this->marker_.pose.position.y,
-                                 this->marker_.pose.position.z));
+                                      this->marker_.pose.orientation.z));
 
     FCL_CollisionObject cobj(this->ptr_fcl_bvh_, x);
     return cobj;

--- a/cob_obstacle_distance/include/cob_obstacle_distance/marker_shapes/marker_shapes_interface.hpp
+++ b/cob_obstacle_distance/include/cob_obstacle_distance/marker_shapes/marker_shapes_interface.hpp
@@ -21,8 +21,19 @@
 #include <boost/shared_ptr.hpp>
 #include <stdint.h>
 #include <visualization_msgs/Marker.h>
-#include <fcl/collision_object.h>
-#include <fcl/BVH/BVH_model.h>
+
+#include <fcl/config.h>
+#if FCL_MINOR_VERSION == 5
+    #include <fcl/collision_object.h>
+    #include <fcl/BVH/BVH_model.h>
+    typedef fcl::RSS FCL_RSS;
+    typedef fcl::CollisionObject FCL_CollisionObject;
+#else
+    #include <fcl/narrowphase/collision_object.h>
+    #include <fcl/geometry/bvh/BVH_model.h>
+    typedef fcl::RSSf FCL_RSS;
+    typedef fcl::CollisionObjectf FCL_CollisionObject;
+#endif
 
 /* BEGIN IMarkerShape *******************************************************************************************/
 /// Interface class marking methods that have to be implemented in derived classes.
@@ -41,7 +52,7 @@ class IMarkerShape
          virtual visualization_msgs::Marker getMarker() = 0;
          virtual void updatePose(const geometry_msgs::Vector3& pos, const geometry_msgs::Quaternion& quat) = 0;
          virtual void updatePose(const geometry_msgs::Pose& pose) = 0;
-         virtual fcl::CollisionObject getCollisionObject() const = 0;
+         virtual FCL_CollisionObject getCollisionObject() const = 0;
          virtual geometry_msgs::Pose getMarkerPose() const = 0;
          virtual geometry_msgs::Pose getOriginRelToFrame() const = 0;
 
@@ -66,6 +77,6 @@ class IMarkerShape
 /* END IMarkerShape *********************************************************************************************/
 
 typedef std::shared_ptr< IMarkerShape > PtrIMarkerShape_t;
-typedef fcl::BVHModel<fcl::RSS> BVH_RSS_t;
+typedef fcl::BVHModel<FCL_RSS> BVH_RSS_t;
 
 #endif /* MARKER_SHAPES_INTERFACE_HPP_ */

--- a/cob_obstacle_distance/include/cob_obstacle_distance/obstacle_distance_data_types.hpp
+++ b/cob_obstacle_distance/include/cob_obstacle_distance/obstacle_distance_data_types.hpp
@@ -24,6 +24,13 @@
 #include <shape_msgs/SolidPrimitive.h>
 #include <visualization_msgs/Marker.h>
 
+#include <fcl/config.h>
+#if FCL_MINOR_VERSION == 5
+    typedef fcl::Vec3f FCL_Vec3;
+#else
+    typedef fcl::Vector3f FCL_Vec3;
+#endif
+
 #define FCL_BOX_X 0u
 #define FCL_BOX_Y 1u
 #define FCL_BOX_Z 2u
@@ -57,9 +64,9 @@ struct ShapeMsgTypeToVisMarkerType
 
 struct TriangleSupport
 {
-    fcl::Vec3f a;
-    fcl::Vec3f b;
-    fcl::Vec3f c;
+    FCL_Vec3 a;
+    FCL_Vec3 b;
+    FCL_Vec3 c;
 };
 
 static ShapeMsgTypeToVisMarkerType g_shapeMsgTypeToVisMarkerType;

--- a/cob_obstacle_distance/include/cob_obstacle_distance/parsers/mesh_parser.hpp
+++ b/cob_obstacle_distance/include/cob_obstacle_distance/parsers/mesh_parser.hpp
@@ -27,7 +27,7 @@
 class MeshParser : public ParserBase
 {
     private:
-        int8_t toVec3f(uint32_t num_current_face, aiVector3D* vertex, fcl::Vec3f& out);
+        int8_t toVec3f(uint32_t num_current_face, aiVector3D* vertex, FCL_Vec3& out);
 
     public:
         MeshParser(const std::string& file_path)

--- a/cob_obstacle_distance/include/cob_obstacle_distance/parsers/parser_base.hpp
+++ b/cob_obstacle_distance/include/cob_obstacle_distance/parsers/parser_base.hpp
@@ -19,8 +19,13 @@
 #define PARSER_BASE_HPP_
 
 #include <stdint.h>
-#include <fcl/BVH/BVH_model.h>
-#include <fcl/math/vec_3f.h>
+
+#include <fcl/config.h>
+#if FCL_MINOR_VERSION == 5
+    #include <fcl/BVH/BVH_model.h>
+#else
+    #include <fcl/geometry/bvh/BVH_model.h>
+#endif
 
 #include "cob_obstacle_distance/obstacle_distance_data_types.hpp"
 

--- a/cob_obstacle_distance/include/cob_obstacle_distance/parsers/stl_parser.hpp
+++ b/cob_obstacle_distance/include/cob_obstacle_distance/parsers/stl_parser.hpp
@@ -26,7 +26,7 @@ class StlParser : public ParserBase
 
         double toDouble(char* facet, uint8_t start_idx);
 
-        fcl::Vec3f toVec3f(char* facet);
+        FCL_Vec3 toVec3f(char* facet);
 
     public:
         StlParser(const std::string& file_path)

--- a/cob_obstacle_distance/package.xml
+++ b/cob_obstacle_distance/package.xml
@@ -21,7 +21,8 @@
   <depend>dynamic_reconfigure</depend>
   <depend>eigen_conversions</depend>
   <depend>eigen</depend>
-  <depend>libfcl-dev</depend>
+  <depend condition="$ROS_DISTRO != noetic">libfcl-dev</depend>
+  <depend condition="$ROS_DISTRO == noetic">fcl</depend>
   <depend>geometry_msgs</depend>
   <depend>kdl_conversions</depend>
   <depend>kdl_parser</depend>

--- a/cob_obstacle_distance/src/cob_obstacle_distance.cpp
+++ b/cob_obstacle_distance/src/cob_obstacle_distance.cpp
@@ -18,9 +18,24 @@
 #include <ctime>
 #include <vector>
 #include <ros/ros.h>
-#include <fcl/shape/geometric_shapes.h>
 #include <fstream>
 #include <thread>
+
+#include <fcl/config.h>
+#if FCL_MINOR_VERSION == 5
+    #include <fcl/shape/geometric_shapes.h>
+    typedef fcl::Box FCL_Box;
+    typedef fcl::Sphere FCL_Sphere;
+    typedef fcl::Cylinder FCL_Cylinder;
+#else
+    #include <fcl/geometry/shape/box.h>
+    #include <fcl/geometry/shape/sphere.h>
+    #include <fcl/geometry/shape/cylinder.h>
+    typedef fcl::Boxf FCL_Box;
+    typedef fcl::Spheref FCL_Sphere;
+    typedef fcl::Cylinderf FCL_Cylinder;
+#endif
+
 
 #include "cob_obstacle_distance/obstacle_distance_data_types.hpp"
 #include "cob_obstacle_distance/distance_manager.hpp"
@@ -70,8 +85,8 @@ int main(int argc, char** argv)
  */
 void addTestObstacles(DistanceManager& dm)
 {
-    fcl::Sphere s(0.1);
-    fcl::Box b(0.1, 0.1, 0.1);  // Take care the nearest point for collision is one of the eight corners!!! This might lead to jittering
+    FCL_Sphere s(0.1);
+    FCL_Box b(0.1, 0.1, 0.1);  // Take care the nearest point for collision is one of the eight corners!!! This might lead to jittering
 
     PtrIMarkerShape_t sptr_Bvh(new MarkerShape<BVH_RSS_t>(dm.getRootFrame(),
                                                           "package://cob_gazebo_objects/Media/models/milk.dae",
@@ -79,7 +94,7 @@ void addTestObstacles(DistanceManager& dm)
                                                            -0.35,
                                                             0.8));
 
-    PtrIMarkerShape_t sptr_Sphere(new MarkerShape<fcl::Sphere>(dm.getRootFrame(), s, 0.35, -0.35, 0.8));
+    PtrIMarkerShape_t sptr_Sphere(new MarkerShape<FCL_Sphere>(dm.getRootFrame(), s, 0.35, -0.35, 0.8));
 
     dm.addObstacle("Funny Sphere", sptr_Sphere);
     dm.addObstacle("Funny Mesh", sptr_Bvh);

--- a/cob_obstacle_distance/src/distance_manager.cpp
+++ b/cob_obstacle_distance/src/distance_manager.cpp
@@ -26,10 +26,16 @@
 
 #include <ros/ros.h>
 
-#include <fcl/collision_object.h>
-#include <fcl/collision.h>
-#include <fcl/distance.h>
-#include <fcl/collision_data.h>
+#include <fcl/config.h>
+#if FCL_MINOR_VERSION == 5
+    #include <fcl/distance.h>
+    typedef fcl::DistanceRequest FCL_DistanceRequest;
+    typedef fcl::DistanceResult FCL_DistanceResult;
+#else
+    #include <fcl/narrowphase/distance.h>
+    typedef fcl::DistanceRequest<double> FCL_DistanceRequest;
+    typedef fcl::DistanceResult<double> FCL_DistanceResult;
+#endif
 
 #include <std_msgs/Float64.h>
 #include <visualization_msgs/Marker.h>
@@ -249,8 +255,8 @@ void DistanceManager::calculate()
         tf::vectorEigenToMsg(abs_jnt_pos, v3);
         ooi->updatePose(v3, quat);
 
-        fcl::CollisionObject ooi_co = ooi->getCollisionObject();
-        fcl::FCL_REAL last_dist = std::numeric_limits<fcl::FCL_REAL>::max();
+        FCL_CollisionObject ooi_co = ooi->getCollisionObject();
+        double last_dist = std::numeric_limits<double>::max();
         {  // introduced the block to lock this critical section until block leaved.
             std::lock_guard<std::mutex> lock(obstacle_mgr_mtx_);
             for (ShapesManager::MapIter_t it = this->obstacle_mgr_->begin(); it != this->obstacle_mgr_->end(); ++it)
@@ -264,9 +270,9 @@ void DistanceManager::calculate()
                 }
 
                 PtrIMarkerShape_t obstacle = it->second;
-                fcl::CollisionObject collision_obj = obstacle->getCollisionObject();
-                fcl::DistanceResult dist_result;
-                fcl::DistanceRequest dist_request(true, 5.0, 0.01);
+                FCL_CollisionObject collision_obj = obstacle->getCollisionObject();
+                FCL_DistanceResult dist_result;
+                FCL_DistanceRequest dist_request(true, 5.0, 0.01);
                 fcl::FCL_REAL dist = fcl::distance(&ooi_co, &collision_obj, dist_request, dist_result);
 
 

--- a/cob_obstacle_distance/src/distance_manager.cpp
+++ b/cob_obstacle_distance/src/distance_manager.cpp
@@ -273,7 +273,9 @@ void DistanceManager::calculate()
                 FCL_CollisionObject collision_obj = obstacle->getCollisionObject();
                 FCL_DistanceResult dist_result;
                 FCL_DistanceRequest dist_request(true, 5.0, 0.01);
-                fcl::FCL_REAL dist = fcl::distance(&ooi_co, &collision_obj, dist_request, dist_result);
+                //FIXME
+                // double dist = fcl::distance(&ooi_co, &collision_obj, dist_request, dist_result);
+                double dist = 0;
 
 
                 Eigen::Vector3d abs_obst_vector(dist_result.nearest_points[1][VEC_X],

--- a/cob_obstacle_distance/src/link_to_collision.cpp
+++ b/cob_obstacle_distance/src/link_to_collision.cpp
@@ -199,16 +199,16 @@ void LinkToCollision::createSpecificMarkerShape(const std::string& link_of_inter
     else if (urdf::Geometry::BOX == geometry->type)
     {
         PtrBox_t urdf_box = std::static_pointer_cast<urdf::Box>(geometry);
-        fcl::Box b(urdf_box->dim.x,
-                   urdf_box->dim.y,
-                   urdf_box->dim.z);
+        FCL_Box b(urdf_box->dim.x,
+                  urdf_box->dim.y,
+                  urdf_box->dim.z);
 
         std_msgs::ColorRGBA test_col;
         test_col.a = 1.0;
         test_col.r = 1.0;
 
-        // segment_of_interest_marker_shape.reset(new MarkerShape<fcl::Box>(this->root_frame_id_, b, pose, col));
-        segment_of_interest_marker_shape.reset(new MarkerShape<fcl::Box>(this->root_frame_id_, b, pose, test_col));
+        // segment_of_interest_marker_shape.reset(new MarkerShape<FCL_Box>(this->root_frame_id_, b, pose, col));
+        segment_of_interest_marker_shape.reset(new MarkerShape<FCL_Box>(this->root_frame_id_, b, pose, test_col));
     }
     else if (urdf::Geometry::SPHERE == geometry->type)
     {
@@ -217,8 +217,8 @@ void LinkToCollision::createSpecificMarkerShape(const std::string& link_of_inter
         test_col.b = 1.0;
 
         PtrSphere_t urdf_sphere = std::static_pointer_cast<urdf::Sphere>(geometry);
-        fcl::Sphere s(urdf_sphere->radius);
-        segment_of_interest_marker_shape.reset(new MarkerShape<fcl::Sphere>(this->root_frame_id_, s, pose, test_col));
+        FCL_Sphere s(urdf_sphere->radius);
+        segment_of_interest_marker_shape.reset(new MarkerShape<FCL_Sphere>(this->root_frame_id_, s, pose, test_col));
     }
     else if (urdf::Geometry::CYLINDER == geometry->type)
     {
@@ -227,8 +227,8 @@ void LinkToCollision::createSpecificMarkerShape(const std::string& link_of_inter
         test_col.g = 1.0;
 
         PtrCylinder_t urdf_cyl = std::static_pointer_cast<urdf::Cylinder>(geometry);
-        fcl::Cylinder c(urdf_cyl->radius, urdf_cyl->length);
-        segment_of_interest_marker_shape.reset(new MarkerShape<fcl::Cylinder>(this->root_frame_id_, c, pose, test_col));
+        FCL_Cylinder c(urdf_cyl->radius, urdf_cyl->length);
+        segment_of_interest_marker_shape.reset(new MarkerShape<FCL_Cylinder>(this->root_frame_id_, c, pose, test_col));
     }
     else
     {
@@ -262,9 +262,9 @@ bool LinkToCollision::getMarkerShapeFromType(const uint32_t& shape_type,
                                              PtrIMarkerShape_t& segment_of_interest_marker_shape)
 {
     // Representation of segment_of_interest as specific fcl::Shape
-    fcl::Box b(dimension(FCL_BOX_X), dimension(FCL_BOX_Y), dimension(FCL_BOX_Z));
-    fcl::Sphere s(dimension(FCL_RADIUS));
-    fcl::Cylinder c(dimension(FCL_RADIUS), dimension(FCL_CYL_LENGTH));
+    FCL_Box b(dimension(FCL_BOX_X), dimension(FCL_BOX_Y), dimension(FCL_BOX_Z));
+    FCL_Sphere s(dimension(FCL_RADIUS));
+    FCL_Cylinder c(dimension(FCL_RADIUS), dimension(FCL_CYL_LENGTH));
     uint32_t loc_shape_type = shape_type;
     std::string mesh_resource;
     if (visualization_msgs::Marker::MESH_RESOURCE == loc_shape_type)
@@ -294,17 +294,17 @@ bool LinkToCollision::getMarkerShapeFromType(const uint32_t& shape_type,
         case visualization_msgs::Marker::CUBE:
             test_col.a = 1.0;
             test_col.r = 1.0;
-            segment_of_interest_marker_shape.reset(new MarkerShape<fcl::Box>(this->root_frame_id_, b, pose, test_col));
+            segment_of_interest_marker_shape.reset(new MarkerShape<FCL_Box>(this->root_frame_id_, b, pose, test_col));
             break;
         case visualization_msgs::Marker::SPHERE:
             test_col.a = 1.0;
             test_col.b = 1.0;
-            segment_of_interest_marker_shape.reset(new MarkerShape<fcl::Sphere>(this->root_frame_id_, s, pose, test_col));
+            segment_of_interest_marker_shape.reset(new MarkerShape<FCL_Sphere>(this->root_frame_id_, s, pose, test_col));
             break;
         case visualization_msgs::Marker::CYLINDER:
             test_col.a = 1.0;
             test_col.g = 1.0;
-            segment_of_interest_marker_shape.reset(new MarkerShape<fcl::Cylinder>(this->root_frame_id_, c, pose, test_col));
+            segment_of_interest_marker_shape.reset(new MarkerShape<FCL_Cylinder>(this->root_frame_id_, c, pose, test_col));
             break;
         case visualization_msgs::Marker::MESH_RESOURCE:
             segment_of_interest_marker_shape.reset(new MarkerShape<BVH_RSS_t>(this->root_frame_id_,

--- a/cob_obstacle_distance/src/marker_shapes/marker_shapes_impl.cpp
+++ b/cob_obstacle_distance/src/marker_shapes/marker_shapes_impl.cpp
@@ -34,9 +34,9 @@ MarkerShape<BVH_RSS_t>::MarkerShape(const std::string& root_frame,
         uint32_t v_idx_2 = tri.vertex_indices.elems[1];
         uint32_t v_idx_3 = tri.vertex_indices.elems[2];
 
-        fcl::Vec3f v1(mesh.vertices[v_idx_1].x, mesh.vertices[v_idx_1].y, mesh.vertices[v_idx_1].z);
-        fcl::Vec3f v2(mesh.vertices[v_idx_2].x, mesh.vertices[v_idx_2].y, mesh.vertices[v_idx_2].z);
-        fcl::Vec3f v3(mesh.vertices[v_idx_3].x, mesh.vertices[v_idx_3].y, mesh.vertices[v_idx_3].z);
+        FCL_Vec3 v1(mesh.vertices[v_idx_1].x, mesh.vertices[v_idx_1].y, mesh.vertices[v_idx_1].z);
+        FCL_Vec3 v2(mesh.vertices[v_idx_2].x, mesh.vertices[v_idx_2].y, mesh.vertices[v_idx_2].z);
+        FCL_Vec3 v3(mesh.vertices[v_idx_3].x, mesh.vertices[v_idx_3].y, mesh.vertices[v_idx_3].z);
 
         this->ptr_fcl_bvh_->addTriangle(v1, v2, v3);
     }
@@ -163,17 +163,16 @@ inline visualization_msgs::Marker MarkerShape<BVH_RSS_t>::getMarker()
 }
 
 
-fcl::CollisionObject MarkerShape<BVH_RSS_t>::getCollisionObject() const
+FCL_CollisionObject MarkerShape<BVH_RSS_t>::getCollisionObject() const
 {
-    fcl::Transform3f x(fcl::Quaternion3f(this->marker_.pose.orientation.w,
-                                         this->marker_.pose.orientation.x,
-                                         this->marker_.pose.orientation.y,
-                                         this->marker_.pose.orientation.z),
-                       fcl::Vec3f(this->marker_.pose.position.x,
-                                  this->marker_.pose.position.y,
-                                  this->marker_.pose.position.z));
-
-    fcl::CollisionObject cobj(this->ptr_fcl_bvh_, x);
+    fcl::Transform3f x(FCL_Quaternion(this->marker_.pose.orientation.w,
+                                      this->marker_.pose.orientation.x,
+                                      this->marker_.pose.orientation.y,
+                                      this->marker_.pose.orientation.z),
+                       FCL_Vec3(this->marker_.pose.position.x,
+                                this->marker_.pose.position.y,
+                                this->marker_.pose.position.z));
+    FCL_CollisionObject cobj(this->ptr_fcl_bvh_, x);
     return cobj;
 }
 

--- a/cob_obstacle_distance/src/marker_shapes/marker_shapes_impl.cpp
+++ b/cob_obstacle_distance/src/marker_shapes/marker_shapes_impl.cpp
@@ -165,13 +165,18 @@ inline visualization_msgs::Marker MarkerShape<BVH_RSS_t>::getMarker()
 
 FCL_CollisionObject MarkerShape<BVH_RSS_t>::getCollisionObject() const
 {
+    // FIXME
+    // fcl::Transform3f x(FCL_Quaternion(this->marker_.pose.orientation.w,
+    //                                   this->marker_.pose.orientation.x,
+    //                                   this->marker_.pose.orientation.y,
+    //                                   this->marker_.pose.orientation.z),
+    //                    FCL_Vec3(this->marker_.pose.position.x,
+    //                             this->marker_.pose.position.y,
+    //                             this->marker_.pose.position.z));
     fcl::Transform3f x(FCL_Quaternion(this->marker_.pose.orientation.w,
                                       this->marker_.pose.orientation.x,
                                       this->marker_.pose.orientation.y,
-                                      this->marker_.pose.orientation.z),
-                       FCL_Vec3(this->marker_.pose.position.x,
-                                this->marker_.pose.position.y,
-                                this->marker_.pose.position.z));
+                                      this->marker_.pose.orientation.z));
     FCL_CollisionObject cobj(this->ptr_fcl_bvh_, x);
     return cobj;
 }

--- a/cob_obstacle_distance/src/parsers/mesh_parser.cpp
+++ b/cob_obstacle_distance/src/parsers/mesh_parser.cpp
@@ -95,13 +95,13 @@ int8_t MeshParser::read(std::vector<TriangleSupport>& tri_vec)
 }
 
 /**
- * Uses the current vertex (assimp 3d vector) and converts into fcl::Vec3f.
+ * Uses the current vertex (assimp 3d vector) and converts into FCL_Vec3.
  * @param num_current_face The number of the current face for error logging.
  * @param vertex Pointer to the current vertex.
  * @param out The fcl vector description.
  * @return Success status (0 means ok).
  */
-int8_t MeshParser::toVec3f(uint32_t num_current_face, aiVector3D* vertex, fcl::Vec3f& out)
+int8_t MeshParser::toVec3f(uint32_t num_current_face, aiVector3D* vertex, FCL_Vec3& out)
 {
     if (!vertex)
     {
@@ -109,7 +109,7 @@ int8_t MeshParser::toVec3f(uint32_t num_current_face, aiVector3D* vertex, fcl::V
         return -3;
     }
 
-    out = fcl::Vec3f((*vertex)[0], (*vertex)[1], (*vertex)[2]);
+    out = FCL_Vec3((*vertex)[0], (*vertex)[1], (*vertex)[2]);
     return 0;
 }
 

--- a/cob_obstacle_distance/src/parsers/stl_parser.cpp
+++ b/cob_obstacle_distance/src/parsers/stl_parser.cpp
@@ -93,13 +93,13 @@ int8_t StlParser::read(std::vector<TriangleSupport>& tri_vec)
  * @param facet Pointer to the current face / triangle in file.
  * @return An fcl::Vec3f containing the 3 vertices describing a triangle.
  */
-fcl::Vec3f StlParser::toVec3f(char* facet)
+FCL_Vec3 StlParser::toVec3f(char* facet)
 {
     double x = this->toDouble(facet, 0);
     double y = this->toDouble(facet, 4);
     double z = this->toDouble(facet, 8);
 
-    fcl::Vec3f v3(x, y, z);
+    FCL_Vec3 v3(x, y, z);
     return v3;
 }
 


### PR DESCRIPTION
migrate fcl according to http://wiki.ros.org/noetic/Migration#Use_fcl_rosdep_key_instead_of_libfcl-dev

example: https://github.com/peci1/robot_body_filter/commit/db08750759d5dd93822451a7c2981368c6bd187b

without https://github.com/ipa320/cob_control/commit/443c0fd0786d091327dcd06e412163a0e2741910 there would still be compilation issues
this commit should be reverted and fixed properly in a follow-up PR