### PR TITLE
[melodic] Feature/invert odom

### DIFF
--- a/cob_omni_drive_controller/src/odom_plugin.cpp
+++ b/cob_omni_drive_controller/src/odom_plugin.cpp
@@ -157,7 +157,10 @@ private:
                 odom_tf_.transform.translation.x = odom_.pose.pose.position.x;
                 odom_tf_.transform.translation.y = odom_.pose.pose.position.y;
                 odom_tf_.transform.rotation = odom_.pose.pose.orientation;
-
+                tf::Transform transform;
+                tf::transformMsgToTF(odom_tf_.transform, transform);
+                geometry_msgs::Transform inverted_transform_msg;
+                tf::transformTFToMsg(transform.inverse(), odom_tf_.transform);
                 // publish the transform (for debugging, conflicts with robot-pose-ekf)
                 tf_broadcast_odometry_->sendTransform(odom_tf_);
             }

--- a/cob_omni_drive_controller/src/odom_plugin.cpp
+++ b/cob_omni_drive_controller/src/odom_plugin.cpp
@@ -51,12 +51,12 @@ public:
             return false;
         }
 
-        const std::string frame_id = controller_nh.param("frame_id", std::string("odom"));
-        const std::string child_frame_id = controller_nh.param("child_frame_id", std::string("base_footprint"));
+        frame_id_ = controller_nh.param("frame_id", std::string("odom"));
+        child_frame_id_ = controller_nh.param("child_frame_id", std::string("base_footprint"));
         const double cov_pose = controller_nh.param("cov_pose", 0.1);
         const double cov_twist = controller_nh.param("cov_twist", 0.1);
 
-        odom_tracker_.reset(new OdometryTracker(frame_id, child_frame_id, cov_pose, cov_twist));
+        odom_tracker_.reset(new OdometryTracker(frame_id_, child_frame_id_, cov_pose, cov_twist));
         odom_ = odom_tracker_->getOdometry();
 
         topic_pub_odometry_ = controller_nh.advertise<nav_msgs::Odometry>("odometry", 1);
@@ -65,8 +65,8 @@ public:
         controller_nh.getParam("broadcast_tf", broadcast_tf);
 
         if(broadcast_tf){
-            odom_tf_.header.frame_id = frame_id;
-            odom_tf_.child_frame_id = child_frame_id;
+            odom_tf_.header.frame_id = frame_id_;
+            odom_tf_.child_frame_id = child_frame_id_;
             tf_broadcast_odometry_.reset(new tf::TransformBroadcaster);
         }
 
@@ -131,6 +131,7 @@ private:
     bool reset_;
     bool invert_odom_ = false;
     boost::mutex mutex_;
+    std::string frame_id_, child_frame_id_;
     geometry_msgs::TransformStamped odom_tf_;
     ros::Time stop_time_;
 
@@ -161,9 +162,10 @@ private:
                 odom_tf_.transform.translation.y = odom_.pose.pose.position.y;
                 odom_tf_.transform.rotation = odom_.pose.pose.orientation;
                 if (invert_odom_){
+                    odom_tf_.header.frame_id = child_frame_id_;
+                    odom_tf_.child_frame_id = frame_id_;
                     tf::Transform transform;
                     tf::transformMsgToTF(odom_tf_.transform, transform);
-                    geometry_msgs::Transform inverted_transform_msg;
                     tf::transformTFToMsg(transform.inverse(), odom_tf_.transform);
                 }
                 // publish the transform (for debugging, conflicts with robot-pose-ekf)

--- a/cob_omni_drive_controller/src/odom_plugin.cpp
+++ b/cob_omni_drive_controller/src/odom_plugin.cpp
@@ -70,7 +70,7 @@ public:
             tf_broadcast_odometry_.reset(new tf::TransformBroadcaster);
         }
 
-        controller_nh.getParam("invert_odom", invert_odom_);
+        controller_nh.getParam("invert_odom_tf", invert_odom_tf_);
 
         publish_timer_ = controller_nh.createTimer(ros::Duration(1 / publish_rate), &OdometryController::publish, this);
         service_reset_ = controller_nh.advertiseService("reset_odometry", &OdometryController::srv_reset, this);
@@ -129,7 +129,7 @@ private:
     ros::Timer publish_timer_;
     nav_msgs::Odometry odom_;
     bool reset_;
-    bool invert_odom_ = false;
+    bool invert_odom_tf_ = false;
     boost::mutex mutex_;
     std::string frame_id_, child_frame_id_;
     geometry_msgs::TransformStamped odom_tf_;
@@ -161,7 +161,7 @@ private:
                 odom_tf_.transform.translation.x = odom_.pose.pose.position.x;
                 odom_tf_.transform.translation.y = odom_.pose.pose.position.y;
                 odom_tf_.transform.rotation = odom_.pose.pose.orientation;
-                if (invert_odom_){
+                if (invert_odom_tf_){
                     odom_tf_.header.frame_id = child_frame_id_;
                     odom_tf_.child_frame_id = frame_id_;
                     tf::Transform transform;

--- a/cob_omni_drive_controller/src/odom_plugin.cpp
+++ b/cob_omni_drive_controller/src/odom_plugin.cpp
@@ -129,7 +129,7 @@ private:
     ros::Timer publish_timer_;
     nav_msgs::Odometry odom_;
     bool reset_;
-    bool invert_odom_ = true;
+    bool invert_odom_ = false;
     boost::mutex mutex_;
     geometry_msgs::TransformStamped odom_tf_;
     ros::Time stop_time_;


### PR DESCRIPTION
introduces the capability to invert the odom tf so we can get a tf-tree like this:
![image](https://user-images.githubusercontent.com/15033292/127489519-743ccf2d-f902-443f-99c3-b39ddd742d9f.png)

```
$ rostopic echo /base/odometry_controller/odometry -n 1
header: 
  seq: 8438
  stamp: 
    secs: 1627560726
    nsecs: 391182772
  frame_id: "odom_wheel"
child_frame_id: "base_footprint"
pose: 
  pose: 
    position: 
      x: -0.9286206985110904
      y: 10.843665335483834
      z: 0.0
    orientation: 
      x: 0.0
      y: 0.0
      z: 0.8923281215810869
      w: 0.4513873319396203
  covariance: [0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1]
twist: 
  twist: 
    linear: 
      x: 0.0
      y: 0.0
      z: 0.0
    angular: 
      x: 0.0
      y: 0.0
      z: 0.0
  covariance: [0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1]
---
