### PR TITLE
Add `halt_detector`

### DIFF
--- a/cob_base_controller_utils/CMakeLists.txt
+++ b/cob_base_controller_utils/CMakeLists.txt
@@ -33,6 +33,10 @@ add_executable(cob_stuck_detector src/stuck_detector.cpp)
 add_dependencies(cob_stuck_detector ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(cob_stuck_detector ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
+add_executable(cob_halt_detector src/halt_detector.cpp)
+add_dependencies(cob_halt_detector ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(cob_halt_detector ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
 ### INSTALL ###
 install(TARGETS cob_spin_detector cob_stop_detector cob_stuck_detector
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/cob_base_controller_utils/CMakeLists.txt
+++ b/cob_base_controller_utils/CMakeLists.txt
@@ -21,6 +21,10 @@ catkin_package(
 
 include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
+add_executable(cob_halt_detector src/halt_detector.cpp)
+add_dependencies(cob_halt_detector ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(cob_halt_detector ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
 add_executable(cob_spin_detector src/spin_detector.cpp)
 add_dependencies(cob_spin_detector ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(cob_spin_detector ${catkin_LIBRARIES} ${Boost_LIBRARIES})
@@ -33,12 +37,8 @@ add_executable(cob_stuck_detector src/stuck_detector.cpp)
 add_dependencies(cob_stuck_detector ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(cob_stuck_detector ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
-add_executable(cob_halt_detector src/halt_detector.cpp)
-add_dependencies(cob_halt_detector ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-target_link_libraries(cob_halt_detector ${catkin_LIBRARIES} ${Boost_LIBRARIES})
-
 ### INSTALL ###
-install(TARGETS cob_spin_detector cob_stop_detector cob_stuck_detector
+install(TARGETS cob_halt_detector cob_spin_detector cob_stop_detector cob_stuck_detector
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/cob_base_controller_utils/launch/halt_detector.launch
+++ b/cob_base_controller_utils/launch/halt_detector.launch
@@ -1,0 +1,18 @@
+<launch>
+  <arg name="stop_timeout" default="10.0" />
+  <arg name="stop_threshold" default="0.001" />
+  <arg name="stuck_timeout" default="1.0" />
+  <arg name="stuck_threshold" default="1.57" />
+  <arg name="recover_after_stuck_timeout" default="3.0" />
+  <arg name="component_name" default="base" />
+
+  <group ns="$(arg component_name)">
+    <node pkg="cob_base_controller_utils" type="cob_halt_detector" name="halt_detector" output="screen">
+        <param name="stop_timeout" type="double" value="$(arg stop_timeout)"/>
+        <param name="stop_threshold" type="double" value="$(arg stop_threshold)"/>
+        <param name="stuck_timeout" type="double" value="$(arg stuck_timeout)"/>
+        <param name="stuck_threshold" type="double" value="$(arg stuck_threshold)"/>
+        <param name="recover_after_stuck_timeout" type="double" value="$(arg recover_after_stuck_timeout)"/>
+    </node>
+  </group>
+</launch>

--- a/cob_base_controller_utils/src/halt_detector.cpp
+++ b/cob_base_controller_utils/src/halt_detector.cpp
@@ -127,6 +127,7 @@ void wheelCommandsCallback(const cob_base_controller_utils::WheelCommands::Const
   bool exceeded = false;
   for (size_t i = 0; i < msg->steer_target_error.size(); ++i) {
     if (fabs(msg->steer_target_error[i]) >= g_stuck_threshold) {
+      ROS_WARN_STREAM("Wheel " << i << " exceeded stuck threshold");
       exceeded = true;
     }
   }

--- a/cob_base_controller_utils/src/halt_detector.cpp
+++ b/cob_base_controller_utils/src/halt_detector.cpp
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2017 Fraunhofer Institute for Manufacturing Engineering and Automation (IPA)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include <ros/ros.h>
+#include <cob_base_controller_utils/WheelCommands.h>
+#include <controller_manager_msgs/SwitchController.h>
+#include <geometry_msgs/Twist.h>
+#include <std_srvs/Trigger.h>
+
+ros::ServiceClient g_halt_client;
+ros::ServiceClient g_recover_client;
+ros::ServiceClient g_switch_controller_client;
+std::vector<std::string> g_controller_spawn;
+ros::Duration g_stop_timeout;
+ros::Duration g_stuck_timeout;
+ros::Duration g_recover_after_stuck_timeout;
+ros::Time g_last_wheel_commands_ok;
+ros::Timer g_stop_timer;
+ros::Timer g_recover_after_stuck_timer;
+double g_stuck_threshold;
+double g_stop_threshold;
+bool g_recovering;
+bool g_is_stopped;
+bool g_is_stuck;
+bool g_stuck_possible;
+
+
+/**
+ * Reload the controllers.
+ */
+void switch_controllers() {
+  controller_manager_msgs::SwitchController switch_srv;
+  switch_srv.request.start_controllers = g_controller_spawn;
+  switch_srv.request.strictness = 1;
+
+  if (g_switch_controller_client.call(switch_srv)) {
+    if (switch_srv.response.ok) {
+      ROS_INFO("Successfully switched controllers");
+    } else {
+      ROS_ERROR("Could not switch controllers");
+    }
+  } else {
+    ROS_ERROR("ServiceCall failed: switch_controller");
+  }
+}
+
+
+/**
+ * Recover the base.
+ */
+void recover() {
+  if (!g_recovering) {
+    g_recovering = true;
+    std_srvs::Trigger srv;
+    g_recover_client.call(srv);
+    switch_controllers();
+    g_is_stopped = false;
+    g_is_stuck = false;
+    g_recovering = false;
+  }
+}
+
+
+/**
+ * Halt the base.
+ */
+void halt() {
+  std_srvs::Trigger srv;
+  g_halt_client.call(srv);
+}
+
+
+/**
+ * Callback for the stop timer.
+ */
+void haltAfterStopTimeoutCallback(const ros::TimerEvent&) {
+  g_is_stopped = true;
+  ROS_INFO_STREAM("Halt, no movement commands received for " << g_stop_timeout << " seconds");
+  halt();
+}
+
+
+/**
+ * Callback for the recover timer after stuck.
+ */
+void recoverAfterStuckCallback(const ros::TimerEvent&) {
+  ROS_INFO("Recovering after stuck");
+  recover();
+  g_stop_timer.start();
+
+  // Wait until the next stuck is possible to prevent "stuck loop"
+  g_stuck_timeout.sleep();
+  g_stuck_possible = true;
+}
+
+
+/**
+ * Callback for wheel commands.
+ *
+ * Calls a halt if the error of the wheel commands exceeded set threshold for
+ * set timeout.
+ *
+ * @param msg WheelCommands message.
+ */
+void wheelCommandsCallback(const cob_base_controller_utils::WheelCommands::ConstPtr& msg) {
+
+  // Initialize last timestamp
+  if (g_last_wheel_commands_ok == ros::Time(0)) {
+    g_last_wheel_commands_ok = msg->header.stamp;
+  }
+
+  // Check if at least one wheel exceeds threshold
+  bool exceeded = false;
+  for (size_t i = 0; i < msg->steer_target_error.size(); ++i) {
+    if (fabs(msg->steer_target_error[i]) >= g_stuck_threshold) {
+      exceeded = true;
+    }
+  }
+
+  // Store current time if not exceeded
+  if (!exceeded) {
+    g_last_wheel_commands_ok = msg->header.stamp;
+  }
+  // Halt if allowed and timeout is reached
+  else if (!g_is_stuck &&
+           !g_is_stopped &&
+           g_stuck_possible &&
+           (msg->header.stamp - g_last_wheel_commands_ok) >= g_stuck_timeout) {
+    g_is_stuck = true;
+    g_stuck_possible = false;
+    g_recover_after_stuck_timer.stop();
+    ROS_ERROR("Halt, robot is stuck");
+    halt();
+    g_recover_after_stuck_timer.start();
+  }
+}
+
+
+/**
+ * Callback for base command twists.
+ *
+ * Restarts the stop_timer if twist exceeds the threshold. Additionally recovers
+ * the base if a twist exceeds the threshold, the base ist not stuck and not yet
+ * recovered.
+ *
+ * @param msg Twist message.
+ */
+void baseCommandsCallback(const geometry_msgs::Twist::ConstPtr& msg) {
+  if (fabs(msg->linear.x) >= g_stop_threshold ||
+       fabs(msg->linear.y) >= g_stop_threshold ||
+       fabs(msg->linear.z) >= g_stop_threshold ||
+       fabs(msg->angular.x) >= g_stop_threshold ||
+       fabs(msg->angular.y) >= g_stop_threshold ||
+       fabs(msg->angular.z) >= g_stop_threshold) {
+    g_stop_timer.stop();
+    if (!g_is_stuck) {
+      if (g_is_stopped) {
+        ROS_INFO("Recovering after stopped");
+        recover();
+      }
+      ROS_DEBUG("Robot is moving, restarting halt timer");
+      g_stop_timer.start();
+    }
+  }
+}
+
+
+int main(int argc, char* argv[])
+{
+  ros::init(argc, argv, "cob_halt_detector");
+
+  ros::NodeHandle nh;
+  ros::NodeHandle nh_priv("~");
+
+  // Get ROS parameter
+  if (!nh_priv.getParam("stop_threshold", g_stop_threshold)) {
+    ROS_ERROR("Please provide a stop threshold");
+    return 1;
+  }
+
+  if (!nh_priv.getParam("stuck_threshold", g_stuck_threshold)) {
+    ROS_ERROR("Please provide a stuck threshold");
+    return 1;
+  }
+
+  double timeout;
+  if(!nh_priv.getParam("stop_timeout", timeout) || timeout <= 0.0){
+    ROS_ERROR("Please provide valid stop timeout");
+    return 1;
+  }
+  g_stop_timeout = ros::Duration(timeout);
+
+  if(!nh_priv.getParam("stuck_timeout", timeout) || timeout <= 0.0){
+    ROS_ERROR("Please provide valid stuck timeout");
+    return 1;
+  }
+  g_stuck_timeout = ros::Duration(timeout);
+
+  if(!nh_priv.getParam("recover_after_stuck_timeout", timeout) || timeout <= 0.0){
+    ROS_ERROR("Please provide valid timeout for recovering after stuck");
+    return 1;
+  }
+  g_recover_after_stuck_timeout = ros::Duration(timeout);
+
+  g_controller_spawn = {"joint_state_controller", "twist_controller"};
+
+  g_last_wheel_commands_ok = ros::Time(0);
+  g_recovering = false;
+  g_is_stopped = false;
+  g_is_stuck = false;
+  g_stuck_possible = true;
+
+  g_halt_client = nh.serviceClient<std_srvs::Trigger>("driver/halt");
+  g_recover_client = nh.serviceClient<std_srvs::Trigger>("driver/recover");
+  g_switch_controller_client = nh.serviceClient<controller_manager_msgs::SwitchController>("controller_manager/switch_controller");
+  g_halt_client.waitForExistence();
+  g_recover_client.waitForExistence();
+  g_switch_controller_client.waitForExistence();
+
+  g_stop_timer = nh.createTimer(g_stop_timeout, haltAfterStopTimeoutCallback, true, false); // oneshot=true, auto_start=false
+  g_recover_after_stuck_timer = nh.createTimer(g_recover_after_stuck_timeout, recoverAfterStuckCallback, true, false); // oneshot=true, auto_start=false
+
+  ros::Subscriber base_commands_sub = nh.subscribe("twist_controller/command", 10, baseCommandsCallback);
+  ros::Subscriber wheel_commands_sub = nh.subscribe("twist_controller/wheel_commands", 10, wheelCommandsCallback);
+
+  ros::spin();
+  return 0;
+}

--- a/cob_base_controller_utils/src/stop_detector.cpp
+++ b/cob_base_controller_utils/src/stop_detector.cpp
@@ -26,7 +26,6 @@ ros::ServiceClient g_recover_client;
 ros::ServiceClient g_switch_client;
 ros::Timer g_halt_timer;
 ros::Timer g_silence_timer;
-ros::Time g_last_received;
 ros::Duration g_timeout;
 double g_threshold;
 bool g_recovered;
@@ -58,54 +57,41 @@ void switch_controller(){
 
 void recover(){
     std_srvs::Trigger srv;
-    ROS_ERROR("RECOVER");
+    ROS_INFO("Recovering");
     g_recover_client.call(srv);
     switch_controller();
-    g_recovered=srv.response.success;
+    g_recovered = srv.response.success;
 }
 
-
+/**
+ * Callback for command twists.
+ *
+ * Restarts the halt_timer if twist exceeds the threshold. Additionally recovers
+ * the base if a twist exceeds the threshold and the base ist not yet recovered.
+ *
+ * @param msg Twist message.
+ */
 void commandsCallback(const geometry_msgs::Twist::ConstPtr& msg){
-    g_last_received = ros::Time::now();
-
-    if(fabs(msg->linear.x)<g_threshold &&
-       fabs(msg->linear.y)<g_threshold &&
-       fabs(msg->linear.z)<g_threshold &&
-       fabs(msg->angular.x)<g_threshold &&
-       fabs(msg->angular.y)<g_threshold &&
-       fabs(msg->angular.z)<g_threshold){
-        if(g_recovered){
-            ROS_WARN_THROTTLE(1.0, "stopped, starting halt_timer");
-            g_halt_timer.start();
-        }else{
-            ROS_DEBUG_THROTTLE(1.0, "stopped - but not active");
-        }
-    }else{
-        ROS_DEBUG_THROTTLE(1.0, "moving...");
+    if (fabs(msg->linear.x) >= g_threshold ||
+        fabs(msg->linear.y) >= g_threshold ||
+        fabs(msg->linear.z) >= g_threshold ||
+        fabs(msg->angular.x) >= g_threshold ||
+        fabs(msg->angular.y) >= g_threshold ||
+        fabs(msg->angular.z) >= g_threshold) {
         g_halt_timer.stop();
-        if(!g_recovered){
-            recover();
+        if (!g_recovered) {
+          recover();
         }
+        ROS_DEBUG("Robot is moving, restarting halt timer");
+        g_halt_timer.start();
     }
 }
 
 void haltCallback(const ros::TimerEvent&){
-    g_halt_timer.stop();  //prevent another call
+    g_recovered = false;
     std_srvs::Trigger srv;
-    ROS_ERROR("HALT");
+    ROS_WARN_STREAM("Halt, no movement commands received for " << g_timeout << " seconds");
     g_halt_client.call(srv);
-    g_recovered=false;
-}
-
-void silenceCallback(const ros::TimerEvent&){
-    if(ros::Time::now()-g_last_received>g_timeout){
-        if(g_recovered){
-            ROS_WARN_THROTTLE(1.0, "silence - calling haltCallback");
-            haltCallback(ros::TimerEvent());
-        }else{
-            ROS_DEBUG_THROTTLE(1.0, "silence - but not active");
-        }
-    }
 }
 
 int main(int argc, char* argv[])
@@ -127,7 +113,6 @@ int main(int argc, char* argv[])
     }
 
     g_recovered = true;
-    g_last_received = ros::Time::now();
     g_timeout = ros::Duration(timeout);
     g_controller_spawn = {"joint_state_controller", "twist_controller"};
 
@@ -138,7 +123,6 @@ int main(int argc, char* argv[])
     g_recover_client.waitForExistence();
     g_switch_client.waitForExistence();
     g_halt_timer = nh.createTimer(g_timeout, haltCallback, true, false); //oneshot=true, auto_start=false
-    g_silence_timer = nh.createTimer(ros::Duration(0.1), silenceCallback, false, true); //oneshot=false, auto_start=true
     ros::Subscriber command_sub = nh.subscribe("twist_controller/command", 10, commandsCallback);
 
     ros::spin();

--- a/cob_base_controller_utils/src/stop_detector.cpp
+++ b/cob_base_controller_utils/src/stop_detector.cpp
@@ -80,7 +80,7 @@ void commandsCallback(const geometry_msgs::Twist::ConstPtr& msg){
         fabs(msg->angular.z) >= g_threshold) {
         g_halt_timer.stop();
         if (!g_recovered) {
-          recover();
+            recover();
         }
         ROS_DEBUG("Robot is moving, restarting halt timer");
         g_halt_timer.start();
@@ -90,7 +90,7 @@ void commandsCallback(const geometry_msgs::Twist::ConstPtr& msg){
 void haltCallback(const ros::TimerEvent&){
     g_recovered = false;
     std_srvs::Trigger srv;
-    ROS_WARN_STREAM("Halt, no movement commands received for " << g_timeout << " seconds");
+    ROS_INFO_STREAM("Halt, no movement commands received for " << g_timeout << " seconds");
     g_halt_client.call(srv);
 }
 


### PR DESCRIPTION
 Adds a new `halt_detector` which is a combination of `stop_detector` and `stuck_detector`. The combination is needed, because the `auto_recover` feature can't be used together with the `stop_detector`.
This detector recovers after a "stuck" and "stops" with respect to the "stuck" state.

Based on https://github.com/ipa320/cob_control/pull/270

 - new source code files added (proper [APACHE license header](https://github.com/ipa320/setup/tree/master/templates) **must** be used)
